### PR TITLE
Llm/adds static size checks for packed structs

### DIFF
--- a/src/comm.h
+++ b/src/comm.h
@@ -3,6 +3,7 @@
 
 #include "const.h"
 #include "inttype.h"
+#include "sassert.h"
 
 /* the communication structure used for exchanging data between the parts of the game has 320 paragraphs, 5120 bytes, 0x1400 */
 #define COMM_SIZE_PARA 0x140
@@ -39,6 +40,8 @@ struct GameComm {
     uint16 gfxModeNum;
     uint16 worldBuf;
 };
+#pragma pack()
+STATIC_ASSERT(sizeof(struct GameComm)==124);
 
 /* end.exe debrief aliases: same struct fields, different semantics after egame writes results */
 #define landingType      setupDone
@@ -95,6 +98,8 @@ struct Game {
     uint8 pad4[8];
     int16 campaignProgress;
 };
+#pragma pack()
+STATIC_ASSERT(sizeof(struct Game)==80);
 
 #define GAME_PILOTIDX_OFFSET 0x0
 #define GAME_PILOTNAME_OFFSET 0x2

--- a/src/dosfunc.c
+++ b/src/dosfunc.c
@@ -126,12 +126,16 @@ struct {
     uint16 ip;
     uint16 cs;
 } exeLoadParams;
+#pragma pack()
+STATIC_ASSERT(sizeof(exeLoadParams)==22);
 
 #pragma pack(1)
 struct {
     uint16 segment;
     uint16 reloc;
 } ovlLoadParams;
+#pragma pack()
+STATIC_ASSERT(sizeof(ovlLoadParams)==4);
 
 #define DOS_LOAD_EXEC 0
 #define DOS_LOAD_NOEXEC 1
@@ -226,6 +230,8 @@ struct MCB {
     uint8 reserved[3];
     char desc[8];
 };
+#pragma pack()
+STATIC_ASSERT(sizeof(struct MCB)==0x10);
 
 static uint8 FAR* dos_sysvars(void) {
     rin.h.ah = DOSF_SYSVARS; 

--- a/src/end.h
+++ b/src/end.h
@@ -151,7 +151,7 @@ extern int *spriteWaypointBlink;
 extern void far pollJoystick(void);
 void processDebriefInput(int *cursorBounds, void *menuItem, int gfxPage);
 
-typedef unsigned int MenuItemFlags;
+typedef uint16 MenuItemFlags;
 
 #define MENUITEM_TYPE_MASK    0x0007 // 0b0000000000000111
 #define MENUITEM_SELECTABLE   0x0008 // 0b0000000000001000
@@ -160,24 +160,25 @@ typedef unsigned int MenuItemFlags;
 #define MENUITEM_SPRITE_BLINK 0x1000 // 0b0001000000000000
 
 typedef struct MenuItem {
-    int  hitX1;          /* 0x00 */
-    int  hitY1;          /* 0x02 */
-    int  hitX2;          /* 0x04 */
-    int  hitY2;          /* 0x06 */
+    int16  hitX1;          /* 0x00 */
+    int16  hitY1;          /* 0x02 */
+    int16  hitX2;          /* 0x04 */
+    int16  hitY2;          /* 0x06 */
 
-    int  colorX1;        /* 0x08 */
-    int  colorY1;        /* 0x0a */
-    int  colorX2;        /* 0x0c */
-    int  colorY2;        /* 0x0e */
-    int  colorTableIdx;  /* 0x10 */
-    int  colorPair;      /* 0x12 */
+    int16  colorX1;        /* 0x08 */
+    int16  colorY1;        /* 0x0a */
+    int16  colorX2;        /* 0x0c */
+    int16  colorY2;        /* 0x0e */
+    int16  colorTableIdx;  /* 0x10 */
+    int16  colorPair;      /* 0x12 */
 
     char label[0x18];    /* 0x14 .. 0x2b */
 
-    int  unk_2c;         /* 0x2c */
-    int  state;          /* 0x2e */
+    int16  unk_2c;         /* 0x2c */
+    int16  state;          /* 0x2e */
     MenuItemFlags flags; /* 0x30 */
 } MenuItem;
+STATIC_ASSERT(sizeof(struct MenuItem)==50);
 
 /* FlightRecord: 6 bytes per record */
 typedef struct {

--- a/src/end1.c
+++ b/src/end1.c
@@ -73,8 +73,7 @@ int readFileAtEx(int handle, int a, int b, int c, int d) {
     return readFileAtExRaw(handle, a, b, c, d);
 }
 
-void closeAndResetFile(p)
-register int *p;
+void closeAndResetFile(register int *p)
 {
     TRACE(("closeAndResetFile"));
     if ((((char *)p)[6] & 0x83) && (((char *)p)[6] & 0x08)) {
@@ -84,8 +83,7 @@ register int *p;
     }
 }
 
-void markHandleClosed(handle)
-int handle;
+void markHandleClosed(int handle)
 {
     TRACE(("markHandleClosed"));
     if (handle != 0) {

--- a/src/end1.c
+++ b/src/end1.c
@@ -73,7 +73,8 @@ int readFileAtEx(int handle, int a, int b, int c, int d) {
     return readFileAtExRaw(handle, a, b, c, d);
 }
 
-void closeAndResetFile(register int *p)
+void closeAndResetFile(p)
+register int *p;
 {
     TRACE(("closeAndResetFile"));
     if ((((char *)p)[6] & 0x83) && (((char *)p)[6] & 0x08)) {
@@ -83,7 +84,8 @@ void closeAndResetFile(register int *p)
     }
 }
 
-void markHandleClosed(int handle)
+void markHandleClosed(handle)
+int handle;
 {
     TRACE(("markHandleClosed"));
     if (handle != 0) {

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -3,6 +3,7 @@
 #include "output.h"
 #include "memory.h"
 #include "offsets.h"
+#include "sassert.h"
 
 #include <STDDEF.H>
 
@@ -20,6 +21,8 @@ struct OvlHeader {
     uint16 slot;
     // Extra description or padding data follows
 };
+#pragma pack()
+STATIC_ASSERT(sizeof(struct OvlHeader)==38);
 
 uint16 overlay_load(const char* filename) {
     const size_t RESERVE_PARA = 0x400;

--- a/src/pointers.h
+++ b/src/pointers.h
@@ -2,6 +2,7 @@
 #define POINTERS_H
 
 #include "inttype.h"
+#include "sassert.h"
 
 #if defined(MSDOS) || defined(__MSDOS__) || defined(MSC_VER)
 #define NEAR near
@@ -26,6 +27,14 @@ union FarAddress {
     struct { uint16 off, seg; } data;
     uint8 FAR *ptr;
 };
+#ifdef HAVE_PRAGMA
+#pragma pack()
+#endif
+#if defined(__clang__) || defined(_MSC_VER) && (_MSC_VER > 510) 
+STATIC_ASSERT(sizeof(union FarAddress)==8);
+#else
+STATIC_ASSERT(sizeof(union FarAddress)==4);
+#endif
 
 #define FARPTR_CAST(type, addr) ((type FAR*)addr.ptr)
 #define FARPTR_CAST_OFFSET(type, addr, offset) (type FAR*)(addr.ptr + offset)

--- a/src/sassert.h
+++ b/src/sassert.h
@@ -1,0 +1,19 @@
+#ifndef SASSERT_H
+#define SASSERT_H
+
+#if defined(__cplusplus)
+  #include <assert.h>
+  #define STATIC_ASSERT(expr) static_assert((expr), #expr)
+  #define STATIC_ASSERT_MSG(expr, msg) static_assert((expr), msg)
+#else
+  #define SA_CAT2_(a,b) a##b
+  #define SA_CAT2(a,b)  SA_CAT2_(a,b)
+  #define STATIC_ASSERT(expr) typedef char SA_CAT2(sa_, __LINE__)[(expr) ? 1 : -1]
+  // msg can't be expressed in MSC 5.1 so we skip the msg
+  #define STATIC_ASSERT_MSG(expr, msg) typedef char SA_CAT2(sa_, __LINE__)[(expr) ? 1 : -1]
+#endif
+    
+// example usage
+// STATIC_ASSERT(sizeof(SomeStruct)==0x32);
+
+#endif /* SASSERT_H */

--- a/src/struct.h
+++ b/src/struct.h
@@ -2,10 +2,12 @@
 #define STRUCT_H
 
 #include "inttype.h"
+#include "sassert.h"
 
 struct JoyAxes {
     uint8 x,y;
 };
+STATIC_ASSERT(sizeof(struct JoyAxes)==2);
 
 #pragma pack(1)
 struct Buf6Item {
@@ -24,6 +26,8 @@ struct Buf6Item {
     uint16 field_1C;
     uint8 field_1E[6];
 };
+#pragma pack()
+STATIC_ASSERT(sizeof(struct Buf6Item)==36);
 #define BUF6ITEMSIZE 0x24
 
 /* Buf4Item: 16-byte world target/object entry from .wld files.
@@ -41,6 +45,8 @@ struct Buf4Item {
     int16 field_C;       /* unknown */
     int16 objectIdx;     /* index into wld_obj_table, masked with 0x7f */
 };
+#pragma pack()
+STATIC_ASSERT(sizeof(struct Buf4Item)==16);
 #define BUF4ITEMSIZE 0x10
 
 #define BUF7SIZE 0x64
@@ -59,6 +65,8 @@ struct Target {
     uint8 coord[6];      /* grid reference string (e.g. "A3B2") */
     int16 distance;      /* distance metric */
 };
+#pragma pack()
+STATIC_ASSERT(sizeof(struct Target)==18);
 
 #define TARGETSIZE 0x12
 
@@ -74,6 +82,8 @@ struct MissionTableEntry {
     int16 missionCode;   /* completion detection flags */
     int16 special;       /* special parameter, can be negative */
 };
+#pragma pack()
+STATIC_ASSERT(sizeof(struct MissionTableEntry)==12);
 
 #define STRUC9SIZE 0xc
 
@@ -82,6 +92,8 @@ struct struc_10 {
     int16 field_0;
     int16 field_2;
 };
+#pragma pack()
+STATIC_ASSERT(sizeof(struct struc_10)==4);
 
 #define STRUC10SIZE 0x4
 #define PILOTNAMELEN 22
@@ -96,6 +108,8 @@ struct Pilot {
     int8 theater; // 0x1e
     int8 difficulty; // 0x1f
 };
+#pragma pack()
+STATIC_ASSERT(sizeof(struct Pilot)==32);
 
 struct Plane {
     int8 field_0[8]; // name
@@ -104,11 +118,17 @@ struct Plane {
     int16 field_14;
     int8 field_16[10];
 };
+STATIC_ASSERT(sizeof(struct Plane)==32);
 #define PLANESIZE 0x20
 
 struct TerrainUnk {
     uint8 *field_0[32];
 };
+STATIC_ASSERT(sizeof(struct TerrainUnk)==sizeof(uint8*)*32);
+// 64 with 16bit ptr
+// 128 with far/32bit ptr
+// 256 with 64bit ptr
+
 #define TERRAINUNKSIZE 64
 
 // used in egame.exe sub_155AB, 16 bytes
@@ -120,6 +140,7 @@ struct struc_1 {
     int16 field_C;
     int16 field_E;
 };
+STATIC_ASSERT(sizeof(struct struc_1)==16);
 
 // used in egame.exe sub_155AB, 0x18 bytes
 struct struc_2 {
@@ -133,6 +154,7 @@ struct struc_2 {
     int16 field_E;
     uint8 field_10[8];
 };
+STATIC_ASSERT(sizeof(struct struc_2)==0x18);
 
 // used in egame.exe sub_155AB, 0x24 bytes
 struct struc_3 {
@@ -141,6 +163,11 @@ struct struc_3 {
     int32 field_6;
     uint8 field_10[26];
 };
+#if defined(__clang__) || defined(_MSC_VER) && (_MSC_VER > 510) 
+STATIC_ASSERT(sizeof(struct struc_3)==40);
+#else
+STATIC_ASSERT(sizeof(struct struc_3)==36);
+#endif
 
 // used in egame.exe, 0x10 bytes
 struct struc_4 {
@@ -152,35 +179,40 @@ struct struc_4 {
     int16 field_C;
     int16 field_E;
 };
+STATIC_ASSERT(sizeof(struct struc_4)==0x10);
 
 // used in egame.exe, 4 bytes
 struct Waypoint {
     uint16 field_0;
     uint16 field_2;
 };
+STATIC_ASSERT(sizeof(struct Waypoint)==4);
 
 // 0x1a bytes
 struct Missile {
     char field_0[10];
     char field_A[12];
-    int field_16;
-    int field_18;
+    int16 field_16;
+    int16 field_18;
 };
+STATIC_ASSERT(sizeof(struct Missile)==26);
 
 // 0x12 bytes
 struct Sam {
     char field_0[8];
-    int field_8;
-    int field_A;
-    int field_C;
-    int field_E;
-    int field_10;
+    int16 field_8;
+    int16 field_A;
+    int16 field_C;
+    int16 field_E;
+    int16 field_10;
 };
+STATIC_ASSERT(sizeof(struct Sam)==18);
 
 // 0x4 bytes
 struct MissileSpec {
-    int field_0;
-    int field_2;
+    int16 field_0;
+    int16 field_2;
 };
+STATIC_ASSERT(sizeof(struct MissileSpec)==4);
 
 #endif // STRUCT_H

--- a/src/test.c
+++ b/src/test.c
@@ -6,7 +6,7 @@
 #include "struct.h"
 #include "debug.h"
 
-void assert(int arg, int lineno, const char *msg, ...) {
+void my_assert(int arg, int lineno, const char *msg, ...) {
     va_list arg_ptr;
 
     if (!arg) {
@@ -18,7 +18,7 @@ void assert(int arg, int lineno, const char *msg, ...) {
     }
 }
 
-#define ASSERT_EQ(a, b) assert(a == b, __LINE__, #a " == " #b " (%d != %d)\n", a, b)
+#define ASSERT_EQ(a, b) my_assert(a == b, __LINE__, #a " == " #b " (%d != %d)\n", a, b)
 
 void testComm() {
     printf("Testing Comm structure layout: ");


### PR DESCRIPTION
in preperation for packing cleanup - the only packing that is relevant is for the MCB struct

without pack(1): 0x12
with pack(1):  0x10

the others are already "packed"

fixed "pack comming from headers" warnings (due to missing pack close) in clang 22.x/VS2022 cl compilation