### PR TITLE
make openBlitClosePic/picBlit compileable on clang

### DIFF
--- a/src/egame.h
+++ b/src/egame.h
@@ -145,7 +145,7 @@ void sub_13224(char *a, int b, char c);
 // ==== seg000:0x3266 ====
 int sub_13266();
 // ==== seg000:0x32ba ====
-int sub_132BA();
+int sub_132BA(int32,int32,int32);
 // ==== seg000:0x345e ====
 void sub_1345E(char *, int, int, int);
 // ==== seg000:0x34ac ====

--- a/src/egame.h
+++ b/src/egame.h
@@ -1678,7 +1678,7 @@ extern int16 word_3C0A0;
 extern char* word_3C0A2[];
 extern int16 word_3C16A;
 extern int16 word_3C16C;
-extern uint8 byte_3C16E[];
+extern char byte_3C16E[];
 extern int16 word_3C45C;
 extern int16 word_3C45E;
 extern int matrix3dt_2[5][32];

--- a/src/egame.h
+++ b/src/egame.h
@@ -468,9 +468,19 @@ int read512FromFileIntoBuf();
 // ==== seg000:0xdf4f ====
 int sub_1DF4F(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4);
 // ==== seg000:0xdfbc ====
-int openBlitClosePic(); // 2 or 3 args?
+ // 2 parameters correct
+#if defined(__clang__)
+void openBlitClosePic(char* path, int arg_2);
+#else
+void openBlitClosePic();
+#endif
 // ==== seg000:0xe0aa ====
-int picBlit(); // 2 or 3 args?
+ // 2 parameters correct
+#if defined(__clang__)
+void picBlit(int handle, int unk);
+#else
+void picBlit();
+#endif
 // ==== seg000:0xe11c ====
 int sub_1E11C();
 // ==== seg000:0xe1f8 ====
@@ -1244,12 +1254,12 @@ extern uint8 byte_380DA[];
 extern char byte_380DD;
 extern int16 word_380E0;
 extern int16 word_380E2;
-extern uint8 a256left_pic[];
-extern uint8 a256right_pic[];
-extern uint8 a256rear_pic[];
-extern uint8 aLeft_pic[];
-extern uint8 aRight_pic[];
-extern uint8 aRear_pic[];
+extern char a256left_pic[];
+extern char a256right_pic[];
+extern char a256rear_pic[];
+extern char aLeft_pic[];
+extern char aRight_pic[];
+extern char aRear_pic[];
 extern int16 word_38126;
 extern uint8 unk_38128[];
 extern int16 word_38152;

--- a/src/egame.h
+++ b/src/egame.h
@@ -241,7 +241,7 @@ void sub_15FDB(void);
 // ==== seg000:0x606c ====
 void sub_1606C(void);
 // ==== seg000:0x60d3 ====
-void sub_160D3(int *arg_0);
+void sub_160D3(int16 *arg_0);
 // ==== seg000:0x613b ====
 void sub_1613B(void);
 // ==== seg000:0x6172 ====
@@ -469,14 +469,14 @@ int read512FromFileIntoBuf();
 int sub_1DF4F(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4);
 // ==== seg000:0xdfbc ====
  // 2 parameters correct
-#if defined(__clang__)
+#if !defined(MSDOS)
 void openBlitClosePic(char* path, int arg_2);
 #else
 void openBlitClosePic();
 #endif
 // ==== seg000:0xe0aa ====
  // 2 parameters correct
-#if defined(__clang__)
+#if !defined(MSDOS)
 void picBlit(int handle, int unk);
 #else
 void picBlit();
@@ -1261,7 +1261,7 @@ extern char aLeft_pic[];
 extern char aRight_pic[];
 extern char aRear_pic[];
 extern int16 word_38126;
-extern uint8 unk_38128[];
+extern int16 unk_38128[];
 extern int16 word_38152;
 extern uint8 aFiring[];
 extern int16 word_3815E;

--- a/src/egame.h
+++ b/src/egame.h
@@ -319,7 +319,11 @@ void __cdecl sub_19DB0(int, int, int, int);
 // ==== seg000:0x9e44 ====
 void __cdecl sub_19E44(int);
 // ==== seg000:0x9e5d ====
+#if !defined(MSDOS)
+void __cdecl sub_19E5D(int arg_0, int arg_2, int arg_4, int arg_6);
+#else
 void __cdecl sub_19E5D();
+#endif
 // ==== seg000:0x9e94 ====
 int sub_19E94();
 // ==== seg000:0x9ea0 ====

--- a/src/egame1.c
+++ b/src/egame1.c
@@ -1901,7 +1901,7 @@ loop:
 }
 
 // ==== seg000:0x60d3 ====
-void sub_160D3(int *arg_0) {
+void sub_160D3(int16 *arg_0) {
     while (*arg_0 != -1) {
         gfx_jump_21(((uint8 *)word_3419C)[*arg_0++]);
         sub_2171A();

--- a/src/egame1.c
+++ b/src/egame1.c
@@ -1922,7 +1922,11 @@ void sub_160D3(int16 *arg_0) {
 void sub_15FDB(void) {
     if (word_330C2 != 0) {
         sub_19E44(0);
+#if !defined(MSDOS)
+        sub_19E5D(0xd4, 0x7f, 0xde, 0xaf/*, 0xc4 garbage*/);
+#else
         sub_19E5D(0xd4, 0x7f, 0xde, 0xaf, 0xc4);
+#endif
         sub_19E44(0x0c);
         sub_19E5D(0xd4, -(var_552 / 3 - 0xaf), 0xde, 0xaf);
         if (100 < var_552) {

--- a/src/egame2.c
+++ b/src/egame2.c
@@ -393,7 +393,7 @@ int sub_189AA(int arg_0) {
 // ==== seg000:0x8df4 ====
 void sub_18DF4(int param_1, int param_2, int param_3) {
     *(char *)&var_315 = 0;
-    sub_132BA((long)param_1 << 5, -((long)param_2 - 0x8000L) << 5, (long)param_3);
+    sub_132BA((int32)param_1 << 5, -((int32)param_2 - 0x8000L) << 5, (int32)param_3);
 }
 
 // ==== seg000:0x85be ====

--- a/src/egame3.c
+++ b/src/egame3.c
@@ -9,7 +9,7 @@
 #include <dos.h>
 #include <memory.h>
 
-#if defined(__clang__)
+#if !defined(MSDOS)
 // ==== seg000:0xdfbc ====
 void openBlitClosePic(char* path, int arg_2) {
     int var_2 = openFileWrapper(path, 0);

--- a/src/egame3.c
+++ b/src/egame3.c
@@ -9,11 +9,21 @@
 #include <dos.h>
 #include <memory.h>
 
+#if defined(__clang__)
 // ==== seg000:0xdfbc ====
-int openBlitClosePic(char* path, int arg_2, int arg_4) {
+void openBlitClosePic(char* path, int arg_2) {
     int var_2 = openFileWrapper(path, 0);
     TRACE(("openBlitClosePic: picBlit(%d, %d)", var_2, arg_2));
-    picBlit(var_2, arg_2, arg_4);
+    picBlit(var_2, arg_2);
     TRACE(("openBlitClosePic: closing"));
     closeFileWrapper(var_2);
 }
+#else
+void openBlitClosePic(char* path, int arg_2, int garbage) {
+    int var_2 = openFileWrapper(path, 0);
+    TRACE(("openBlitClosePic: picBlit(%d, %d)", var_2, arg_2));
+    picBlit(var_2, arg_2, garbage);
+    TRACE(("openBlitClosePic: closing"));
+    closeFileWrapper(var_2);
+}
+#endif

--- a/src/end0.c
+++ b/src/end0.c
@@ -231,7 +231,11 @@ void drawFlightLine(int p1, int p2, int p3, int p4)
 void drawWrappedText(int16 *page, char *str, unsigned int maxWidth, int x, int y, int lineHeight) {
     int p;
     char *a;
+#if !defined(MSDOS)
+    char *b;
+#else
     uint8 *b;
+#endif
     int c;
     int d;
     char *e;

--- a/src/shared/util.c
+++ b/src/shared/util.c
@@ -43,7 +43,7 @@ void drawStringCentered(int16 *page, const char *str, int startx, int y, int end
 
 int stringWidth(int16 *page, const char *str) {
     int n;
-#if defined(__clang__)
+#if !defined(MSDOS)
     const char* l; // clang errors due to wrong type but char does change the binary
 #else
     const uint8* l;

--- a/src/struct.h
+++ b/src/struct.h
@@ -163,7 +163,7 @@ struct struc_3 {
     int32 field_6;
     uint8 field_10[26];
 };
-#if defined(__clang__) || defined(_MSC_VER) && (_MSC_VER > 510) 
+#if !defined(MSDOS) || defined(_MSC_VER) && (_MSC_VER > 510)
 STATIC_ASSERT(sizeof(struct struc_3)==40);
 #else
 STATIC_ASSERT(sizeof(struct struc_3)==36);


### PR DESCRIPTION
keep garbage parameter for MSC 5.1 binary compatibility

im currently using `#if defined(__clang__)` to separate my changes

