### PR TITLE
Add NO_ASM build for end.exe and stub overlay functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,5 @@ jobs:
       - name: Verify end.exe
         run: make verify-end
 
-      - name: Build noasm-start
-        run: make noasm-start
+      - name: Build noasm
+        run: make -j$(nproc) noasm-start noasm-end

--- a/Makefile
+++ b/Makefile
@@ -260,6 +260,26 @@ $(END_DEBUG): $(DEBUGDIR) $(END_DBG_OBJ)
 	fi
 
 #
+# end.exe NO_ASM build (pure C graphics, no overlay needed)
+#
+END_NOASM := $(NOASMDIR)/end.exe
+NOASM_END_SRC := $(END_SRC) gfx_impl.c
+NOASM_END_COBJ := $(call cobj,$(NOASMDIR),$(NOASM_END_SRC)) $(addprefix $(NOASMDIR)/,$(NOASM_SHARED_SRC:.c=.obj))
+NOASM_END_OBJ := $(NOASM_END_COBJ) $(NOASMDIR)/util.obj $(NOASMDIR)/util2.obj
+$(NOASM_END_COBJ): $(END_BASEHDR)
+$(NOASM_END_COBJ): MSC_CFLAGS := /Gs /Zi /Id:\f15-se2 /DNO_ASM
+$(END_NOASM): | $(NOASMDIR)
+$(END_NOASM): $(NOASM_END_OBJ)
+	@$(DOSBUILD) link $(LINK_TOOLCHAIN) -i $(NOASM_END_OBJ) -o $@ -f "$(LINKFLAGS)" -l "slibce.lib"
+	@if [ -n "$(F15_TESTDIR)" ]; then \
+	    echo "Copying $@ to $(F15_TESTDIR)"; \
+	    cp $@ "$(F15_TESTDIR)"; \
+		ls -l $(F15_TESTDIR)/end.exe; \
+	fi
+
+noasm-end: $(END_NOASM)
+
+#
 # unit test executable
 #
 TEST_EXE := $(DEBUGDIR)/test.exe

--- a/src/enmain.c
+++ b/src/enmain.c
@@ -6,6 +6,21 @@
 #include <stdlib.h>
 #include "end.h"
 
+#ifdef NO_ASM
+void clearKeybuf(void) {
+    while (misc_jump_5a_keybuf() == 0) {
+        misc_jump_5b_getkey();
+    }
+}
+
+void setupWorldBufPtr(void) {
+    uint16 seg = FP_SEG(commData);
+    uint16 off = FP_OFF(commData);
+    worldBufOffset = off + 0x7A;
+    worldBufSegment = seg;
+}
+#endif
+
 void initGraphics(void) {
     int a, b, c, d, e, f, g, h;
     (void)a; (void)b; (void)c; (void)d;

--- a/src/shared/file_io.c
+++ b/src/shared/file_io.c
@@ -69,6 +69,77 @@ int writeFileAtRaw(int handle, void far *buf, uint16 count)
     return r.x.ax;
 }
 
+/* dos_free: Free DOS memory block (INT 21h/49h) */
+int dos_free(int segment)
+{
+    union REGS r;
+    struct SREGS s;
+    r.h.ah = 0x49;
+    s.es = segment;
+    intdosx(&r, &r, &s);
+    if (r.x.cflag) return r.x.ax;
+    return 0;
+}
+
+/* createFile: Create or truncate file (INT 21h/3Ch) */
+int createFile(const char *filename, int attr)
+{
+    union REGS r;
+    struct SREGS s;
+    r.h.ah = 0x3C;
+    r.x.cx = attr;
+    segread(&s);
+    r.x.dx = (uint16)filename;
+    intdosx(&r, &r, &s);
+    if (r.x.cflag) return -1;
+    return r.x.ax;
+}
+
+/* readFile: Read from file into DS-relative buffer (INT 21h/3Fh) */
+int readFile(int handle, int count, int bufOffset)
+{
+    union REGS r;
+    struct SREGS s;
+    r.h.ah = 0x3F;
+    r.x.bx = handle;
+    r.x.cx = count;
+    r.x.dx = bufOffset;
+    segread(&s);
+    intdosx(&r, &r, &s);
+    if (r.x.cflag) return -1;
+    return r.x.ax;
+}
+
+/* readFileAt: Read from file into specific segment:offset (INT 21h/3Fh) */
+int readFileAt(int handle, int count, int offset, int segment)
+{
+    union REGS r;
+    struct SREGS s;
+    r.h.ah = 0x3F;
+    r.x.bx = handle;
+    r.x.cx = count;
+    r.x.dx = offset;
+    s.ds = segment;
+    intdosx(&r, &r, &s);
+    if (r.x.cflag) return -1;
+    return r.x.ax;
+}
+
+/* writeFile: Write to file from specific segment:offset (INT 21h/40h) */
+int writeFile(int handle, int count, int offset, int segment, int unused)
+{
+    union REGS r;
+    struct SREGS s;
+    r.h.ah = 0x40;
+    r.x.bx = handle;
+    r.x.cx = count;
+    r.x.dx = offset;
+    s.ds = segment;
+    intdosx(&r, &r, &s);
+    if (r.x.cflag) return -1;
+    return r.x.ax;
+}
+
 /* file_read512.inc: Read 512 bytes from file - stub */
 int read512FromFileIntoBuf(void)
 {

--- a/src/shared/miscstub.c
+++ b/src/shared/miscstub.c
@@ -52,7 +52,8 @@ uint8 *outreg;
     outreg[1] = r.h.ah;
 }
 
-void setupOverlaySlots(void)
+void setupOverlaySlots(param)
+int param;
 {
     miscdbg("setupOverlaySlots called");
 }

--- a/src/shared/ovlstub.c
+++ b/src/shared/ovlstub.c
@@ -17,9 +17,6 @@ static void ovldbg(const char *msg)
     if (f) { fputs(msg, f); fputs("\r\n", f); fclose(f); }
 }
 
-/* Shared game state variables (used by multiple executables) */
-struct GameComm far *commData = 0;
-struct Game far *gameData = 0;
 uint8  hercFlag = 0;
 uint8  exitCode = 0;
 int16  fileHandle = 0;

--- a/src/shared/picstub.c
+++ b/src/shared/picstub.c
@@ -333,6 +333,13 @@ void decodePic(int handle, int segment)
     picDecodeToSegment(handle, (uint16)segment);
 }
 
+void decodePicRaw(int handle, int segment)
+{
+    /* Same as decodePic: clears page and decodes PIC row-by-row */
+    gfx_clearPage();
+    picDecodeToSegment(handle, (uint16)segment);
+}
+
 void picBlit(int handle, int segment)
 {
     decodePic(handle, segment);


### PR DESCRIPTION
- Add Makefile target for pure C end.exe build (no overlay)
- Implement NO_ASM stubs in enmain.c and miscstub.c
- Add DOS file I/O helpers to file_io.c
- Add decodePicRaw to picstub.c
- Remove commData/gameData from ovlstub.c