### PR TITLE
Apply bugfixes and update function signatures for cross-platform build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,11 +137,11 @@ NOASM_SHARED_SRC := file_io.c timer.c miscstub.c gfxstub.c picstub.c ovlstub.c
 NOASM_COBJ := $(call cobj,$(NOASMDIR),$(NOASM_SRC)) $(addprefix $(NOASMDIR)/,$(NOASM_SHARED_SRC:.c=.obj))
 NOASM_OBJ := $(NOASM_COBJ) $(NOASMDIR)/util.obj $(NOASMDIR)/util2.obj
 $(NOASM_COBJ): $(START_BASEHDR)
-$(NOASM_COBJ): MSC_CFLAGS := /Gs /Zi /Id:\f15-se2 /DNO_ASM
+$(NOASM_COBJ): MSC_CFLAGS := /Gs /Zi /Id:\f15-se2 /DNO_ASM /DBUGFIX
 $(NOASMDIR)/util.obj: $(SRCDIR)/shared/util.c $(HDRS) | $(NOASMDIR)
-	@$(DOSBUILD) cc $(C_TOOLCHAIN) -i $< -o $@ -f "/Gs /I.. /Id:\f15-se2 /DNO_ASM"
+	@$(DOSBUILD) cc $(C_TOOLCHAIN) -i $< -o $@ -f "/Gs /I.. /Id:\f15-se2 /DNO_ASM /DBUGFIX"
 $(NOASMDIR)/util2.obj: $(SRCDIR)/shared/util2.c $(HDRS) | $(NOASMDIR)
-	@$(DOSBUILD) cc $(C_TOOLCHAIN) -i $< -o $@ -f "/Gs /I.. /Id:\f15-se2 /DNO_ASM"
+	@$(DOSBUILD) cc $(C_TOOLCHAIN) -i $< -o $@ -f "/Gs /I.. /Id:\f15-se2 /DNO_ASM /DBUGFIX"
 $(START_NOASM): | $(NOASMDIR)
 $(START_NOASM): $(NOASM_OBJ)
 	@$(DOSBUILD) link $(LINK_TOOLCHAIN) -i $(NOASM_OBJ) -o $@ -f "$(LINKFLAGS)" -l "slibce.lib"
@@ -158,7 +158,7 @@ $(NOASMDIR)/%.obj: $(SRCDIR)/%.c $(HDRS) | $(NOASMDIR)
 	@$(DOSBUILD) cc $(C_TOOLCHAIN) -i $< -o $@ -f "$(MSC_CFLAGS)"
 
 $(NOASMDIR)/%.obj: $(SRCDIR)/shared/%.c $(HDRS) | $(NOASMDIR)
-	@$(DOSBUILD) cc $(C_TOOLCHAIN) -i $< -o $@ -f "/Gs /Zi /I.. /Id:\f15-se2 /DNO_ASM"
+	@$(DOSBUILD) cc $(C_TOOLCHAIN) -i $< -o $@ -f "/Gs /Zi /I.. /Id:\f15-se2 /DNO_ASM /DBUGFIX"
 
 $(NOASMDIR)/%.obj: $(SRCDIR)/%.asm | $(NOASMDIR)
 	$(ASM) $(ASMFLAGS) -Fo$@ $<
@@ -278,7 +278,7 @@ NOASM_END_SRC := $(END_SRC) gfx_impl.c
 NOASM_END_COBJ := $(call cobj,$(NOASMDIR),$(NOASM_END_SRC)) $(addprefix $(NOASMDIR)/,$(NOASM_SHARED_SRC:.c=.obj))
 NOASM_END_OBJ := $(NOASM_END_COBJ) $(NOASMDIR)/util.obj $(NOASMDIR)/util2.obj
 $(NOASM_END_COBJ): $(END_BASEHDR)
-$(NOASM_END_COBJ): MSC_CFLAGS := /Gs /Zi /Id:\f15-se2 /DNO_ASM
+$(NOASM_END_COBJ): MSC_CFLAGS := /Gs /Zi /Id:\f15-se2 /DNO_ASM /DBUGFIX
 $(END_NOASM): | $(NOASMDIR)
 $(END_NOASM): $(NOASM_END_OBJ)
 	@$(DOSBUILD) link $(LINK_TOOLCHAIN) -i $(NOASM_END_OBJ) -o $@ -f "$(LINKFLAGS)" -l "slibce.lib"

--- a/src/egame.h
+++ b/src/egame.h
@@ -460,7 +460,7 @@ int sub_1DDAA();
 // ==== seg000:0xddc4 ====
 int __cdecl openFile(char *, int);
 // ==== seg000:0xde1b ====
-int createFile(int arg_0, int arg_1);
+int createFile(const char *arg_0, int arg_1);
 // ==== seg000:0xde72 ====
 int closeFile(int arg_0);
 // ==== seg000:0xde94 ====
@@ -473,18 +473,10 @@ int read512FromFileIntoBuf();
 int sub_1DF4F(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4);
 // ==== seg000:0xdfbc ====
  // 2 parameters correct
-#if !defined(MSDOS)
 void openBlitClosePic(char* path, int arg_2);
-#else
-void openBlitClosePic();
-#endif
 // ==== seg000:0xe0aa ====
  // 2 parameters correct
-#if !defined(MSDOS)
 void picBlit(int handle, int unk);
-#else
-void picBlit();
-#endif
 // ==== seg000:0xe11c ====
 int sub_1E11C();
 // ==== seg000:0xe1f8 ====

--- a/src/eghud.c
+++ b/src/eghud.c
@@ -344,8 +344,8 @@ int sub_155AB() {
 void sub_15FDB(void) {
     if (word_330C2 != 0) {
         sub_19E44(0);
-#if !defined(MSDOS)
-        sub_19E5D(0xd4, 0x7f, 0xde, 0xaf/*, 0xc4 garbage*/);
+#ifdef BUGFIX
+        sub_19E5D(0xd4, 0x7f, 0xde, 0xaf);
 #else
         sub_19E5D(0xd4, 0x7f, 0xde, 0xaf, 0xc4);
 #endif

--- a/src/egpic.c
+++ b/src/egpic.c
@@ -9,21 +9,16 @@
 #include <dos.h>
 #include <memory.h>
 
-#if !defined(MSDOS)
-// ==== seg000:0xdfbc ====
+#ifdef BUGFIX
 void openBlitClosePic(char* path, int arg_2) {
-    int var_2 = openFileWrapper(path, 0);
-    TRACE(("openBlitClosePic: picBlit(%d, %d)", var_2, arg_2));
-    picBlit(var_2, arg_2);
-    TRACE(("openBlitClosePic: closing"));
-    closeFileWrapper(var_2);
-}
 #else
 void openBlitClosePic(char* path, int arg_2, int garbage) {
+#endif
     int var_2 = openFileWrapper(path, 0);
-    TRACE(("openBlitClosePic: picBlit(%d, %d)", var_2, arg_2));
+#ifdef BUGFIX
+    picBlit(var_2, arg_2);
+#else
     picBlit(var_2, arg_2, garbage);
-    TRACE(("openBlitClosePic: closing"));
+#endif
     closeFileWrapper(var_2);
 }
-#endif

--- a/src/enaward.c
+++ b/src/enaward.c
@@ -40,7 +40,11 @@ void loadPicFromFileAt(char *name, int segment, int off, int whence) {
     int handle;
     TRACE(("loadPicFromFileAt"));
     handle = openFileWrapper(name, 0);
+#ifdef BUGFIX
+    lseek(handle, off, whence);
+#else
     lseek(handle, off, whence, 0);
+#endif
     decodePic(handle, segment);
     closeFileWrapper(handle);
 }

--- a/src/end.h
+++ b/src/end.h
@@ -67,22 +67,13 @@
 /* calcMissionScore: compute score for all events */
 #define SCORE_ALL_EVENTS    0x100
 
-void closeFileWrapper(int handle);
-
 /* ASM functions called from C */
-void restoreTimerIrqHandler(void);
-void setTimerIrqHandler(void);
-void intDispatch(int intNum, uint8 *inRegs, uint8 *outRegs);
-void restoreCbreakHandler(void);
-int getTimeOfDay(void);
 void srandInit(int seed);
 void decodePic(int handle, int segment);
-void showPicFile(int handle, int page, int garbage);
 int dos_alloc(int size);
 void dos_printstring(const char *str);
 int dos_free(int segment);
-int openFile(char *name, int mode);
-int createFile(char *name, int mode);
+int createFile(const char *name, int mode);
 int readFile(int handle, int buf, int size);
 int readFileAt(int handle, int a, int b, int c);
 int writeFile(int handle, int a, int b, int c, int d);
@@ -266,8 +257,6 @@ extern MenuItem debriefMenuItems[];
 
 /* Reconstructed C functions */
 void seedRandom(void);
-void loadPic(char *filename, int segment);
-void openShowPic(char *name, int page);
 uint16 allocBuffer(int size);
 void freeBuffer(int segment);
 void srandInit(int seed);
@@ -277,7 +266,7 @@ void drawClippedLineEx(int x1, int y1, int x2, int y2, int cx1, int cy1, int cx2
 void drawClippedLine(int x1, int y1, int x2, int y2);
 int drawEventSprite(int recordIdx);
 void drawMapPixel(int x, int y, int color);
-int isPointInRect(void *p);
+int isPointInRect(struct MenuItem *p);
 void blinkWidget(MenuItem *item, int16* gfxPage);
 unsigned int drawFlightPath(int16 *gfxPage, unsigned int maxRecord);
 void showEventPopup(void);
@@ -442,7 +431,6 @@ extern int missionResult;
 extern int selectedMenuItem;
 
 /* ASM functions called by main */
-void setupOverlaySlots(int param);
 void clearKeybuf(void);
 void loadWorldStrings(void);
 void setupWorldBufPtr(void);
@@ -450,7 +438,6 @@ void readWorldData(void);
 void loadTheaterIndex(void);
 void debriefMainLoop(void);
 void showPostMissionAwards(void);
-void installCBreakHandler(void);
 extern void far copyJoystickData(uint8 far *data);
 
 /* File I/O variables */

--- a/src/enmain.c
+++ b/src/enmain.c
@@ -34,7 +34,7 @@ void initGraphics(void) {
     gfx_storeBufPtr(commData->gfxInitResult, 1);
 }
 
-void main(void) {
+int main(void) {
     int p;
     int a;
     int b;

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -408,7 +408,7 @@ int FAR CDECL gfx_setColor(int color)
 int FAR CDECL gfx_initOverlay(void) { return 0; }
 int FAR CDECL gfx_setPage1(void) { g_curPageSeg = g_pageSegs[1]; return 0; }
 int FAR CDECL gfx_getCurPageSeg2(void) { return (int)g_curPageSeg; }
-int FAR CDECL gfx_getCurPage(void) { return (int)g_curPageSeg; }
+int FAR CDECL gfx_getCurPage(int page) { return (int)g_curPageSeg; }
 int FAR CDECL gfx_blitSprite(struct SpriteParams *p)
 {
     uint16 srcSeg, dstSeg;
@@ -503,8 +503,8 @@ int FAR CDECL gfx_nop36(void) { return 0; }
 int FAR CDECL gfx_nop37(void) { return 0; }
 int FAR CDECL gfx_setFadeSteps(int steps) { (void)steps; return 0; }
 int FAR CDECL gfx_calcRowAddr(int y, int x) { return (int)(g_rowOffsets[y] + (uint16)x); }
-int FAR CDECL gfx_setOvlVal1(void) { return 0; }
-int FAR CDECL gfx_setOvlVal2(void) { return 0; }
+int FAR CDECL gfx_setOvlVal1(int val) { return 0; }
+int FAR CDECL gfx_setOvlVal2(int val) { return 0; }
 int FAR CDECL gfx_getBlitOffset(void) { return (int)g_blitOffset; }
 int FAR CDECL gfx_getModeFlag(void) { return (int)g_modeFlag; }
 int FAR CDECL gfx_getModeFlag2(void) { return (int)g_modeFlag; }

--- a/src/inttype.h
+++ b/src/inttype.h
@@ -28,7 +28,7 @@
  * 
  * long = 4, int =2, short = 2, char = 1, near = 2, far = 4, size = 2
  */
-#if defined(MSDOS) || defined(__MSDOS__) || defined(MSC_VER)
+#if defined(MSDOS) || defined(__MSDOS__)
 typedef unsigned long uint32;
 typedef unsigned int uint16;
 typedef unsigned char uint8;
@@ -41,7 +41,7 @@ typedef int bool;
 #define true 1
 #define false 0
 #else
-#include <cstdint>
+#include <stdint.h>
 typedef uint32_t uint32;
 typedef uint16_t uint16;
 typedef uint8_t uint8;
@@ -49,6 +49,13 @@ typedef uint8_t uint8;
 typedef int32_t int32;
 typedef int16_t int16;
 typedef int8_t int8;
+
+#ifndef __cplusplus
+typedef int bool;
+#define true 1
+#define false 0
+#endif
+
 #endif
 
 #endif /* INTTYPE_H */

--- a/src/pointers.h
+++ b/src/pointers.h
@@ -14,30 +14,7 @@
 #define CDECL
 #endif
 
-#if !defined(__TURBOC__) && !defined(MK_FP)
 #define MK_FP(a,off) ((void FAR *) (((unsigned long)(a) << 16) | (unsigned long)(off)))
-#endif
-
-#if !defined(offsetof)
-#define offsetof(st, m) ((size_t)&(((st*)0)->m))
-#endif
-
-#ifdef HAVE_PRAGMA
-#pragma pack(1)
-#endif
-union FarAddress {
-    struct { uint16 off, seg; } data;
-    uint8 FAR *ptr;
-};
-#ifdef HAVE_PRAGMA
-#pragma pack()
-#endif
-#if defined(__clang__) || defined(_MSC_VER) && (_MSC_VER > 510) 
-STATIC_ASSERT(sizeof(union FarAddress)==8);
-#else
-STATIC_ASSERT(sizeof(union FarAddress)==4);
-#endif
-
 #define MAKEFAR(type, seg, off) ((type FAR *)MK_FP(seg, off))
 
 #endif /* POINTERS_H */

--- a/src/shared/gfxstub.c
+++ b/src/shared/gfxstub.c
@@ -6,6 +6,7 @@
 #include "inttype.h"
 #include "pointers.h"
 #include "slot.h"
+#include <dos.h>
 
 /* Dirty rect tracking variables - these are declared in the data module */
 extern int16 dirtyMinBuf[];

--- a/src/shared/miscstub.c
+++ b/src/shared/miscstub.c
@@ -27,16 +27,18 @@ void pollJoystick(void)
 {
 }
 
-void copyJoystickData(void)
+int far copyJoystickData(uint8 *ptr)
 {
+    return 0;
 }
 
-void mystrcat(char *dst, const char *src)
+int mystrcat(char *dst, char *src)
 {
     strcat(dst, src);
+    return 0;
 }
 
-void intDispatch(int16 intnum, uint8 *inreg, uint8 *outreg)
+void intDispatch(int intnum, uint8 *inreg, uint8 *outreg)
 {
     union REGS r;
     /* inreg[0] = AL, inreg[1] = AH based on stinit.c usage */
@@ -52,12 +54,14 @@ void setupOverlaySlots(int param)
     miscdbg("setupOverlaySlots called");
 }
 
-void doNothing2(void)
+int doNothing2(const char *msg, int a, int b, int c)
 {
+    return 0;
 }
 
-void getTimeOfDay(uint8 *regs)
+int getTimeOfDay(void)
 {
+    return 0;
 }
 
 int mystrlen(const char *s)
@@ -65,7 +69,7 @@ int mystrlen(const char *s)
     return strlen(s);
 }
 
-void nearmemset(char *dst, int val, int count)
+void nearmemset(void *dst, char val, int count)
 {
     memset(dst, val, count);
 }
@@ -75,7 +79,7 @@ int loadOverlay(const char *filename)
     return 0;
 }
 
-int doFcbSearch(void *fcb)
+int doFcbSearch(void)
 {
     return -1;
 }

--- a/src/shared/ovlstub.c
+++ b/src/shared/ovlstub.c
@@ -17,9 +17,9 @@ static void ovldbg(const char *msg)
     if (f) { fputs(msg, f); fputs("\r\n", f); fclose(f); }
 }
 
-uint8  hercFlag = 0;
-uint8  exitCode = 0;
-int16  fileHandle = 0;
+extern uint8  hercFlag;
+extern uint8  exitCode;
+extern int16  fileHandle;
 
 /* Misc input overlay slots - real DOS keyboard I/O */
 int far cdecl misc_jump_5a_keybuf(void) {
@@ -36,10 +36,10 @@ int far cdecl misc_jump_5b_getkey(void) {
     int86(0x16, &regs, &regs);
     return regs.x.ax;
 }
-int far cdecl misc_jump_5d_readJoy(void) { return 0; }
+int far cdecl misc_jump_5d_readJoy(int16 param) { return 0; }
 int far cdecl misc_jump_5e_clearKeyFlags(void) { ovldbg("clearKeyFlags"); return 0; }
 
 /* Audio overlay slots */
-int far cdecl audio_jump_64(void) { return 0; }
+int far cdecl audio_jump_64(int16 a, int16 b) { return 0; }
 int far cdecl audio_jump_65(void) { return 0; }
 int far cdecl audio_jump_67(void) { return 0; }

--- a/src/shared/picstub.c
+++ b/src/shared/picstub.c
@@ -19,7 +19,7 @@ void picdbg(const char *msg)
 }
 
 /* Pic decode work data */
-uint8 picDecodedRowBuf[320];
+extern uint8 picDecodedRowBuf[320];
 /* Large buffers allocated from DOS to save DGROUP space */
 static uint8 far *picWorkDataFar;
 static uint16 far *picDecodeDictionaryFar;
@@ -314,10 +314,9 @@ static void picDecodeToSegment(int handle, uint16 pageSeg)
     }
 }
 
-void showPicFile(int handle, int page, int unused)
+void showPicFile(int handle, int page)
 {
     uint16 pageSeg;
-    (void)unused;
 
     if (handle < 0) return;
 

--- a/src/shared/util.c
+++ b/src/shared/util.c
@@ -8,10 +8,11 @@
 #include "util.h"
 
 #include "../pointers.h"
+#include <dos.h>
 
 /* extern declarations needed by these functions */
 extern void far gfx_drawString(int16 *pageNum, const char *string);
-extern int far gfx_setFont(int ch, int font);
+extern int far gfx_setFont(uint16 ch, uint16 font);
 extern void far misc_jump_5e_clearKeyFlags(void);
 extern char timerHandlerInstalled;
 void restoreTimerIrqHandler(void);
@@ -58,7 +59,7 @@ int stringWidth(int16 *page, const char *str) {
     return n;
 }
 
-void my_ltoa(int32 value, int8* buf) {
+void my_ltoa(int32 value, char* buf) {
     int8 i, k;
     int8 *p;
     int8 n[6];

--- a/src/shared/util.h
+++ b/src/shared/util.h
@@ -17,6 +17,29 @@ void my_itoa(int value, char *buf);
 
 /* functions provided by util2.c */
 int openFileWrapper(char *filename, int mode);
+void closeFileWrapper(int handle);
 void mystrcpy(char *dest, const char *source);
+void loadPic(const char *filename, int segment);
+#ifdef BUGFIX
+void openShowPic(char *name, int page);
+void showPicFile(int handle, int pageNum);
+#else
+void openShowPic(char *name, int page, int garbage);
+void showPicFile(int handle, int pageNum, int garbage);
+#endif
+
+/* functions provided by file_io.c / file_*.inc */
+int openFile(const char *filename, int mode);
+
+/* functions provided by miscstub.c / overlay_dispatch.inc */
+void intDispatch(int intNum, uint8 *inRegs, uint8 *outRegs);
+void restoreCbreakHandler(void);
+void installCBreakHandler(void);
+void setupOverlaySlots(int param);
+int getTimeOfDay(void);
+
+/* functions provided by timer.c / timer_*.inc */
+void setTimerIrqHandler(void);
+void restoreTimerIrqHandler(void);
 
 #endif /* UTIL_H */

--- a/src/shared/util2.c
+++ b/src/shared/util2.c
@@ -6,10 +6,9 @@
 #include "util.h"
 #include "../debug.h"
 
-int openFile(char *name, int mode);
+int openFile(const char *name, int mode);
 int fileClose(int handle);
 int decodePic(int handle, int segment);
-void showPicFile(int handle, int pageNum, int garbage);
 
 int openFileWrapper(char *filename, int mode)
 {
@@ -27,7 +26,7 @@ void closeFileWrapper(int handle)
     fileClose(handle);
 }
 
-void loadPic(char *filename, uint16 segment) {
+void loadPic(const char *filename, int segment) {
     int handle;
     handle = openFileWrapper(filename, 0);
     TRACE(("loadPic(): opened %s, loading into segment 0x%x", filename, segment));
@@ -35,13 +34,21 @@ void loadPic(char *filename, uint16 segment) {
     closeFileWrapper(handle);
 }
 
-void openShowPic(char *name, int16 page, int16 garbage)
+#ifdef BUGFIX
+void openShowPic(char *name, int page)
+#else
+void openShowPic(char *name, int page, int garbage)
+#endif
 {
     int16 fileHandle;
     TRACE(("openShowPic: opening file %s, page %d",name,page));
     fileHandle = openFileWrapper(name, 0);
     TRACE(("openShowPic: showing pic, handle %d",fileHandle));
+#ifdef BUGFIX
+    showPicFile(fileHandle, page);
+#else
     showPicFile(fileHandle, page, garbage);
+#endif
     closeFileWrapper(fileHandle);
     TRACE(("openShowPic: file closed, returning"));
 }

--- a/src/slot.h
+++ b/src/slot.h
@@ -73,16 +73,16 @@ int FAR CDECL gfx_setFadeSteps(int steps);             /* slot 0x3d: setFadeStep
 int FAR CDECL gfx_calcRowAddr(int y, int x);           /* slot 0x3e: calcRowAddr */
 /* dseg:0xbf3 */
 int FAR CDECL gfx_getModecode();                       /* slot 0x3f: returns 3 (MCGA) */
-int FAR CDECL gfx_setOvlVal1();                        /* slot 0x40: writes ds:0xcc */
-int FAR CDECL gfx_setOvlVal2();                        /* slot 0x41: writes ds:0xce */
+int FAR CDECL gfx_setOvlVal1(int val);                 /* slot 0x40: writes ds:0xcc */
+int FAR CDECL gfx_setOvlVal2(int val);                 /* slot 0x41: writes ds:0xce */
 int FAR CDECL gfx_getModeFlag2();                      /* slot 0x42: returns modeFlag */
 int FAR CDECL gfx_unknown43();                         /* slot 0x43: unknown */
 int FAR CDECL gfx_setDac(uint16 palIdx);               /* slot 0x44: set VGA DAC palette */
 int FAR CDECL gfx_waitRetrace();                       /* slot 0x45: wait for vblank */
 int FAR CDECL gfx_flipPage();                          /* slot 0x46: vblank + flip to VGA */
-int FAR CDECL gfx_blitSpriteClipped(int16* ptr);      /* slot 0x47: sprite variant */
+int FAR CDECL gfx_blitSpriteClipped(int16* ptr);       /* slot 0x47: sprite variant */
 int FAR CDECL gfx_blitSpriteClipped2();                /* slot 0x48: sprite variant */
-int FAR CDECL gfx_blitSpriteOpaque(int16* ptr);       /* slot 0x49: sprite blit (=0x11) */
+int FAR CDECL gfx_blitSpriteOpaque(int16* ptr);        /* slot 0x49: sprite blit (=0x11) */
 int FAR CDECL gfx_blitSpriteOpaque2();                 /* slot 0x4a: blit core (=0x12) */
 /* dseg:0xc2f */
 int FAR CDECL gfx_storeBufPtr(uint16 seg, int pageIdx); /* slot 0x4b: pageSegs[idx]=seg */
@@ -93,7 +93,7 @@ int FAR CDECL gfx_setDacAnimCount(uint16 count);       /* slot 0x4f: setDacAnimC
 int FAR CDECL gfx_commitPage();                        /* slot 0x50: commitPage */
 int FAR CDECL gfx_nop51();                             /* slot 0x51: retf */
 int FAR CDECL gfx_setMonoFlag(uint16 mono);            /* slot 0x52: setMonoFlag */
-int FAR CDECL gfx_getCurPage();                        /* slot 0x53: returns curPageSeg */
+int FAR CDECL gfx_getCurPage(int page);                /* slot 0x53: returns curPageSeg */
 int FAR CDECL gfx_slot54();
 int FAR CDECL gfx_slot55();
 int FAR CDECL gfx_slot56();

--- a/src/start.h
+++ b/src/start.h
@@ -9,6 +9,9 @@
 
 #if !defined(MSDOS) && !defined(__MSDOS__)
 #define far
+#define near
+#define _interrupt
+#define __interrupt
 #endif
 
 #define __int32 long
@@ -105,15 +108,12 @@ int unreach_1130B();
 int sub_11458();
 void seedRandom();
 int __cdecl randMul(unsigned int);
-void setTimerIrqHandler(void);
-void restoreTimerIrqHandler(void);
 int sub_118B9();
 int sub_118D1();
 int far timerIrqHandler();
 int timerIrqCallback();
 int calibrateTimerSpeed();
 int manipulateTimer();
-int getTimeOfDay();
 int increaseTimerCounters();
 int doFcbSearch();
 void picBlit(int handle, int unk);
@@ -143,7 +143,6 @@ void farmemset(char far *dst, char value, int count);
 int my_memcpy();
 int unreach_127AE();
 int sub_127CA();
-void intDispatch(int intNum, uint8 *inregs, uint8 *outregs);
 int myItoa();
 int base10_itoa();
 int base16_itoa();
@@ -151,7 +150,6 @@ int base2_itoa();
 int unreach_1292C();
 int dos_printstring(const char *str);
 int loadOverlay(const char *filename);
-void setupOverlaySlots(int ovlSegment);
 int unreach_12AE1();
 int sub_12B1B();
 void __cdecl clearRect(int16 *buf, int x, int y, int maxx, int maxy);
@@ -162,19 +160,15 @@ int drawLineWrapper();
 int clipAndDrawLine();
 int computeOutcode();
 int far sub_12F8B();
-int installCBreakHandler();
-void restoreCbreakHandler(void);
 int getInterruptHandler();
 int far cbreakHandler();
 int unreach_12FFC(int filename, int a);
 int unreach_13032(int filename, int a, int b);
 int unreach_1306A();
 int unreach_130B4();
-void closeFileWrapper(int handle);
 int unreach_130D4();
 int unreach_130E8();
 int unreach_13100();
-int openFile(char *filename, int mode);
 int unreach_13171();
 int fileClose(int handle);
 int unreach_131EA();
@@ -183,11 +177,8 @@ int unreach_13243();
 int read512FromFileIntoBuf();
 int unreach_1328D();
 int writeFileAtRaw();
-void openShowPic(char *filename, int pageNum);
 int unreach_1333E(int filename, int a);
-void __cdecl loadPic(char *, unsigned int);
 void unreach_loadPicAt();
-void showPicFile(int handle, int pageNum, int garbage);
 int unreach_13442();
 int unreach_134AA();
 int decodePic(int handle, int segment);
@@ -201,7 +192,7 @@ uint16 __cdecl allocBuffer(int sz);
 int unreach_freeBuffer(int freeSeg);
 unsigned int __cdecl dos_alloc(int sz);
 int unreach_dos_freeMem(int freeSeg);
-int *__cdecl findNearestTerrain(__int32, __int32);
+int16 *__cdecl findNearestTerrain(__int32, __int32);
 unsigned __int32 __cdecl scaleCoordByLevel(int, unsigned __int32);
 int __cdecl lookupGridCell(int, int, int);
 void parseGridTerrain(void);
@@ -865,7 +856,7 @@ extern uint8 gridBuf4[];
 extern int16 page1Ptr;
 extern uint8 libc_bufout[];
 extern uint8 gridBuf3[];
-extern int *nearestTerrainResult;
+extern int16 *nearestTerrainResult;
 extern uint8 gridBuf2[];
 extern struct TerrainTile terrainTileBlock[];
 extern uint8 wldReadBuf1[];

--- a/src/stdata.c
+++ b/src/stdata.c
@@ -2,6 +2,7 @@
 #include "struct.h"
 #include "comm.h"
 #include <stdio.h>
+#include <dos.h>
 
 /* === Group 1 (0x0042-0x0530): Filename, mission selection, UI strings === */
 char aLabs_pic[] = "labs.pic";
@@ -706,7 +707,7 @@ char todayMissStrBuf[0x1D];
 uint8 missionStrTrunc;
 uint8 missionStrTruncEnd;
 uint8 exitCode[2];
-int *nearestTerrainResult;
+int16 *nearestTerrainResult;
 char objectTypeTable[0x64];
 uint8 wldReadBuf8[0x64];
 uint8 wldReadBuf7[0x64];

--- a/src/stgen.c
+++ b/src/stgen.c
@@ -6,6 +6,7 @@
 #include "comm.h"
 #include "debug.h"
 #include "const.h"
+#include "shared/util.h"
 
 #include <memory.h>
 #include <dos.h>

--- a/src/stinit.c
+++ b/src/stinit.c
@@ -38,7 +38,7 @@ void initGraphics()
 }
 
 
-void clearKeyBuf()
+void clearKeybuf()
 {
     while (misc_jump_5a_keybuf() == 0) {
         misc_jump_5b_getkey();

--- a/src/stmain.c
+++ b/src/stmain.c
@@ -7,6 +7,7 @@
 #include "const.h"
 #include "debug.h"
 #include "start.h"
+#include "shared/util.h"
 
 #include <dos.h>
 

--- a/src/strand.c
+++ b/src/strand.c
@@ -1,5 +1,6 @@
 /* Random number utilities */
 #include "start.h"
+#include "shared/util.h"
 
 #include <dos.h>
 


### PR DESCRIPTION
- Add /DBUGFIX to NOASM build flags in Makefile
- Update function signatures in headers and stubs for consistency
- Remove MSDOS-specific #ifdefs in favor of BUGFIX where needed
- Fix types and prototypes for openFile, createFile, showPicFile, etc.
- Add missing includes and externs for cross-module references
- Rename clearKeyBuf to clearKeybuf for consistency
- Update util and util2 functions to match corrected signatures
- Adjust slot.h and gfx_impl.c for updated overlay slot prototypes
- Fix inttype.h typedefs and includes for portability
- Remove redundant or incorrect extern/global variable definitions
- Ensure all function declarations and calls match across modules