### PR TITLE
Add 64-bit native build support via CMake CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,24 @@ jobs:
 
       - name: Build noasm
         run: make -j$(nproc) noasm-start noasm-end
+
+  build-64bit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Configure CMake
+        run: cmake -S . -B build64
+
+      - name: Build f15
+        run: cmake --build build64 --target f15 -j$(nproc)
+
+      - name: Build start
+        run: cmake --build build64 --target start -j$(nproc)
+
+      - name: Build end
+        run: cmake --build build64 --target end -j$(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,159 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(f15 LANGUAGES CXX)
+
+set(SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+set(SHARED_SOURCES
+    ${SRC_DIR}/shared/file_io.c
+    ${SRC_DIR}/shared/gfxstub.c
+    ${SRC_DIR}/shared/miscstub.c
+    ${SRC_DIR}/shared/ovlstub.c
+    ${SRC_DIR}/shared/picstub.c
+    ${SRC_DIR}/shared/timer.c
+    ${SRC_DIR}/shared/util.c
+    ${SRC_DIR}/shared/util2.c
+)
+
+set(START_SOURCES
+    ${SRC_DIR}/stmain.c
+    ${SRC_DIR}/stinit.c
+    ${SRC_DIR}/stmissn.c
+    ${SRC_DIR}/stsprit.c
+    ${SRC_DIR}/strand.c
+    ${SRC_DIR}/stpilot.c
+    ${SRC_DIR}/stpinp.c
+    ${SRC_DIR}/stinkey.c
+    ${SRC_DIR}/stalloc.c
+    ${SRC_DIR}/stterr.c
+    ${SRC_DIR}/stparse.c
+    ${SRC_DIR}/stgrid.c
+    ${SRC_DIR}/stgen.c
+    ${SRC_DIR}/stdata.c
+    ${SRC_DIR}/gfx_impl.c
+    ${SHARED_SOURCES}
+)
+
+set(EGAME_SOURCES
+    ${SRC_DIR}/egmain.c
+    ${SRC_DIR}/eg3d_a.c
+    ${SRC_DIR}/eg3d_b.c
+    ${SRC_DIR}/eg3d_c.c
+    ${SRC_DIR}/eg3d_d.c
+    ${SRC_DIR}/eg3d_e.c
+    ${SRC_DIR}/eg3d_f.c
+    ${SRC_DIR}/eg3d_g.c
+    ${SRC_DIR}/eghud.c
+    ${SRC_DIR}/egflight.c
+    ${SRC_DIR}/egtacmap.c
+    ${SRC_DIR}/egui.c
+    ${SRC_DIR}/egwaypt.c
+    ${SRC_DIR}/egmath.c
+    ${SRC_DIR}/egweap.c
+    ${SRC_DIR}/egfileio.c
+    ${SRC_DIR}/egpic.c
+    ${SRC_DIR}/egfarbuf.c
+)
+
+set(END_SOURCES
+    ${SRC_DIR}/enmain.c
+    ${SRC_DIR}/enworld.c
+    ${SRC_DIR}/eninput.c
+    ${SRC_DIR}/entext.c
+    ${SRC_DIR}/enaward.c
+    ${SRC_DIR}/enbrief.c
+    ${SRC_DIR}/endbrf.c
+    ${SRC_DIR}/enfile.c
+    ${SRC_DIR}/end_data.c
+    ${SRC_DIR}/gfx_impl.c
+    ${SHARED_SOURCES}
+)
+
+set(F15_SOURCES
+    ${SRC_DIR}/f15.c
+    ${SRC_DIR}/dosfunc.c
+    ${SRC_DIR}/biosfunc.c
+    ${SRC_DIR}/output.c
+    ${SRC_DIR}/overlay.c
+    ${SRC_DIR}/f15util.c
+)
+
+add_executable(f15 ${F15_SOURCES})
+add_executable(start ${START_SOURCES})
+add_executable(egame ${EGAME_SOURCES})
+add_executable(end ${END_SOURCES})
+
+# Treat .c files as C++17 (decompiled code uses C++ features)
+function(configure_f15_target target_name)
+    set_source_files_properties(${ARGN} PROPERTIES LANGUAGE CXX)
+
+    target_include_directories(${target_name} BEFORE PRIVATE
+        ${SRC_DIR}/compat64
+        ${SRC_DIR}
+        ${SRC_DIR}/shared
+    )
+
+    target_compile_definitions(${target_name} PRIVATE BUGFIX NO_ASM)
+    target_compile_features(${target_name} PRIVATE cxx_std_17)
+
+    if(
+        CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+        OR
+        (
+            CMAKE_CXX_COMPILER_ID MATCHES "Clang"
+            AND
+            NOT CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC"
+        )
+    )
+        target_compile_options(${target_name} PRIVATE
+            -Wall
+
+            -Wno-unused
+            -Wno-unused-variable
+            -Wno-unused-parameter
+            -Wno-unused-function
+            -Wno-unused-but-set-variable
+            -Wno-deprecated-declarations
+            -Wno-deprecated
+
+            $<$<CXX_COMPILER_ID:Clang>:-ferror-limit=1000>
+            $<$<CXX_COMPILER_ID:AppleClang>:-ferror-limit=1000>
+            $<$<CXX_COMPILER_ID:GNU>:-fmax-errors=1000>
+
+            -fpermissive
+            -Wno-int-to-pointer-cast
+            -Wno-pointer-to-int-cast
+            -Wno-narrowing
+        )
+
+    elseif(
+        MSVC
+        OR
+        CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC"
+    )
+        target_compile_options(${target_name} PRIVATE
+            /nologo
+            /TP
+            /W3
+            /wd4100  # unreferenced formal parameter
+            /wd4101  # unreferenced local variable
+            /wd4189  # local variable initialized but not referenced
+            /wd4996  # deprecated / unsafe CRT
+            /wd4244  # conversion, possible loss of data
+            /wd4267  # size_t -> smaller type
+            /wd4305  # truncation
+            /wd4311  # pointer truncation
+            /wd4312  # conversion to pointer of greater size
+        )
+
+    else()
+        message(WARNING "Unknown C++ compiler: ${CMAKE_CXX_COMPILER_ID}")
+    endif()
+endfunction()
+
+configure_f15_target(f15 ${F15_SOURCES})
+configure_f15_target(start ${START_SOURCES})
+configure_f15_target(egame ${EGAME_SOURCES})
+configure_f15_target(end ${END_SOURCES})

--- a/src/compat64/bios.h
+++ b/src/compat64/bios.h
@@ -1,0 +1,12 @@
+#pragma once
+// Minimal bios.h stub for 64-bit native builds
+
+#ifndef _BIOS_H_COMPAT64
+#define _BIOS_H_COMPAT64
+
+#define _KEYBRD_READY 1
+#define _KEYBRD_READ 0
+
+inline int _bios_keybrd(int cmd) { (void)cmd; return 0; }
+
+#endif // _BIOS_H_COMPAT64

--- a/src/compat64/conio.h
+++ b/src/compat64/conio.h
@@ -1,0 +1,10 @@
+#pragma once
+// Minimal conio.h stub for 64-bit native builds
+// getch/putch/kbhit are already provided by our dos.h compat header
+
+#ifndef _CONIO_H_COMPAT64
+#define _CONIO_H_COMPAT64
+
+#include <dos.h>
+
+#endif // _CONIO_H_COMPAT64

--- a/src/compat64/dos.h
+++ b/src/compat64/dos.h
@@ -1,0 +1,93 @@
+#pragma once
+// Minimal dos.h stub for 64-bit native builds
+
+#ifndef _DOS_H_COMPAT64
+#define _DOS_H_COMPAT64
+
+#define _CDECL
+#define cdecl
+#define far
+#define FAR
+#define near
+#define pascal
+#define interrupt
+#define _interrupt
+#define __interrupt
+#define register
+
+// FP_SEG/FP_OFF: In 64-bit builds, far pointers don't exist.
+// Use reinterpret_cast to provide lvalue access to the high/low 16-bit words of a 32-bit-sized pointer slot.
+// This won't produce meaningful addresses but allows the code to compile.
+#define FP_SEG(fp) (((unsigned short*)&(fp))[1])
+#define FP_OFF(fp) (((unsigned short*)&(fp))[0])
+
+struct WORDREGS {
+    unsigned short ax;
+    unsigned short bx;
+    unsigned short cx;
+    unsigned short dx;
+    unsigned short si;
+    unsigned short di;
+    unsigned short cflag;
+};
+
+struct BYTEREGS {
+    unsigned char al, ah;
+    unsigned char bl, bh;
+    unsigned char cl, ch;
+    unsigned char dl, dh;
+};
+
+union REGS {
+    struct WORDREGS x;
+    struct BYTEREGS h;
+};
+
+struct SREGS {
+    unsigned short es;
+    unsigned short cs;
+    unsigned short ss;
+    unsigned short ds;
+};
+
+inline int intdos(union REGS* inregs, union REGS* outregs) { (void)inregs; (void)outregs; return 0; }
+inline int intdosx(union REGS* inregs, union REGS* outregs, struct SREGS* segregs) { (void)inregs; (void)outregs; (void)segregs; return 0; }
+inline int int86(int intno, union REGS* inregs, union REGS* outregs) { (void)intno; (void)inregs; (void)outregs; return 0; }
+inline int int86x(int intno, union REGS* inregs, union REGS* outregs, struct SREGS* segregs) { (void)intno; (void)inregs; (void)outregs; (void)segregs; return 0; }
+inline void segread(struct SREGS* segregs) { (void)segregs; }
+inline void movedata(unsigned int srcseg, unsigned int srcoff, unsigned int dstseg, unsigned int dstoff, unsigned int nbytes) { (void)srcseg; (void)srcoff; (void)dstseg; (void)dstoff; (void)nbytes; }
+
+inline void _chain_intr(void (*handler)()) { (void)handler; }
+typedef void (*_dos_isr_t)();
+inline _dos_isr_t _dos_getvect(unsigned intno) { (void)intno; return 0; }
+inline void _dos_setvect(unsigned intno, _dos_isr_t handler) { (void)intno; (void)handler; }
+
+inline int inp(unsigned int port) { (void)port; return 0; }
+inline int outp(unsigned int port, int value) { (void)port; (void)value; return 0; }
+
+inline unsigned short _psp = 0;
+
+// Non-standard C functions used by the codebase
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <stdio.h>
+#include <unistd.h>
+
+inline int getch(void) { return 0; }
+inline int putch(int c) { (void)c; return 0; }
+inline int kbhit(void) { return 0; }
+
+inline char* itoa(int value, char* str, int base) {
+    if (base == 10) { sprintf(str, "%d", value); }
+    else if (base == 16) { sprintf(str, "%x", value); }
+    else { str[0] = '\0'; }
+    return str;
+}
+
+inline char* strupr(char* s) {
+    for (char* p = s; *p; p++) *p = toupper((unsigned char)*p);
+    return s;
+}
+
+#endif // _DOS_H_COMPAT64

--- a/src/egame.h
+++ b/src/egame.h
@@ -7,7 +7,7 @@
 
 #include <stdio.h>
 
-#if !defined(MSDOS) && !defined(__MSDOS__)
+#if !defined(MSDOS)
 #define far
 #ifndef pascal
 #define pascal
@@ -1803,7 +1803,7 @@ extern uint8 var_316;
 extern int16 var_665;
 extern int16 var_666;
 
-#if defined(MSDOS) || defined(__MSDOS__)
+#if defined(MSDOS)
 extern int rand();
 #endif
 extern long _aNlmul(long, long);

--- a/src/end.h
+++ b/src/end.h
@@ -8,10 +8,6 @@
 #include <stdio.h>
 #include <dos.h>
 
-#if !defined(MSDOS) && !defined(__MSDOS__)
-#define far
-#endif
-
 #define __int32 long
 #define __int8 char
 #define __cdecl
@@ -177,6 +173,7 @@ typedef uint16 MenuItemFlags;
 #define MENUITEM_HAS_SPRITE   0x0800 // 0b0000100000000000
 #define MENUITEM_SPRITE_BLINK 0x1000 // 0b0001000000000000
 
+#pragma pack(1)
 typedef struct MenuItem {
     int16  hitX1;          /* 0x00 */
     int16  hitY1;          /* 0x02 */
@@ -200,7 +197,8 @@ typedef struct MenuItem {
     int16  state;          /* 0x2e */
     MenuItemFlags flags; /* 0x30 */
 } MenuItem;
-STATIC_ASSERT(sizeof(struct MenuItem)==50);
+#pragma pack()
+STATIC_ASSERT(sizeof(struct MenuItem) == 44 + 3 * sizeof(void*));
 
 void processDebriefInput(int *cursorBounds, MenuItem *menuItem, int16* gfxPage);
 

--- a/src/end_data.c
+++ b/src/end_data.c
@@ -3,6 +3,7 @@
 #include "inttype.h"
 #include "struct.h"
 #include "comm.h"
+#include <dos.h>
 
 /* Split into chunks due to MSC 5.1 initializer limits.
  *

--- a/src/gfx_impl.h
+++ b/src/gfx_impl.h
@@ -32,24 +32,6 @@ typedef struct {
     int16 maxX[220];  /* 0x1B8: per-row maximum dirty X */
 } DirtyRectBuf;
 
-/* Page descriptor / "rastport" structure.
- * Passed as int16* to drawString, switchColor, blitSprite, etc.
- * The overlay accesses fields at word offsets [0]..[10+].
- */
-typedef struct {
-    int16 pageNum;    /* [0] page index into pageSegs[] */
-    int16 flags;      /* [1] rendering flags */
-    int16 color;      /* [2] current draw color */
-    int16 font;       /* [3] font index */
-    int16 x;          /* [4] cursor/draw X position */
-    int16 y;          /* [5] cursor/draw Y position */
-    int16 field_6;    /* [6] misc (often 0) */
-    int16 clipMinX;   /* [7] clip rect left */
-    int16 clipMaxX;   /* [8] clip rect right */
-    int16 clipMinY;   /* [9] clip rect top */
-    int16 clipMaxY;   /* [10] clip rect bottom */
-} PageDesc;
-
 /* Sprite blit parameter block.
  * Passed to slots 0x11/0x47/0x49 as int16* pointer.
  * The overlay loads BP from the pointer and accesses [bp+N].

--- a/src/inttype.h
+++ b/src/inttype.h
@@ -28,7 +28,7 @@
  * 
  * long = 4, int =2, short = 2, char = 1, near = 2, far = 4, size = 2
  */
-#if defined(MSDOS) || defined(__MSDOS__)
+#if defined(MSDOS)
 typedef unsigned long uint32;
 typedef unsigned int uint16;
 typedef unsigned char uint8;

--- a/src/pointers.h
+++ b/src/pointers.h
@@ -4,10 +4,12 @@
 #include "inttype.h"
 #include "sassert.h"
 
-#if defined(MSDOS) || defined(__MSDOS__) || defined(MSC_VER)
+#if defined(MSDOS)
 #define NEAR near
 #define FAR far
 #define CDECL cdecl
+
+#define offsetof(st, m) ((size_t)&(((st*)0)->m))
 #else
 #define NEAR
 #define FAR

--- a/src/shared/miscstub.c
+++ b/src/shared/miscstub.c
@@ -83,3 +83,20 @@ int doFcbSearch(void)
 {
     return -1;
 }
+
+#if !defined(MSDOS)
+int16 *findNearestTerrain(long a, long b)
+{
+    return 0;
+}
+
+unsigned long scaleCoordByLevel(int level, unsigned long coord)
+{
+    return coord;
+}
+
+int dos_alloc(int size)
+{
+    return 0;
+}
+#endif

--- a/src/start.h
+++ b/src/start.h
@@ -6,13 +6,7 @@
 #include "pointers.h"
 
 #include <stdio.h>
-
-#if !defined(MSDOS) && !defined(__MSDOS__)
-#define far
-#define near
-#define _interrupt
-#define __interrupt
-#endif
+#include <dos.h>
 
 #define __int32 long
 #define __int8 char
@@ -90,7 +84,7 @@ int setenvp();
 void clearKeybuf(void);
 void waitJoyKey(void);
 int joyOrKey();
-void waitMdaCgaStatus(int);
+void waitMdaCgaStatus(int16);
 void drawLine(int16 *pageNum, int x1, int y1, int x2, int y2, int color);
 void showPic640(char *filename);
 void missionSelect(void);
@@ -107,7 +101,7 @@ int dead_drawWrappedText();
 int unreach_1130B();
 int sub_11458();
 void seedRandom();
-int __cdecl randMul(unsigned int);
+int __cdecl randMul(uint16);
 int sub_118B9();
 int sub_118D1();
 int far timerIrqHandler();
@@ -117,7 +111,7 @@ int manipulateTimer();
 int increaseTimerCounters();
 int doFcbSearch();
 void picBlit(int handle, int unk);
-void pilotSelect(int ps_needSplash);
+void pilotSelect(int16 ps_needSplash);
 void updateHallfame();
 void displayPilots(void);
 void __cdecl printPilot(int);
@@ -194,7 +188,7 @@ unsigned int __cdecl dos_alloc(int sz);
 int unreach_dos_freeMem(int freeSeg);
 int16 *__cdecl findNearestTerrain(__int32, __int32);
 unsigned __int32 __cdecl scaleCoordByLevel(int, unsigned __int32);
-int __cdecl lookupGridCell(int, int, int);
+int __cdecl lookupGridCell(int16, int16, int16);
 void parseGridTerrain(void);
 void parseTerrain(char *dest);
 void parseGrid();

--- a/src/struct.h
+++ b/src/struct.h
@@ -172,17 +172,15 @@ struct struc_2 {
 STATIC_ASSERT(sizeof(struct struc_2)==0x18);
 
 // used in egame.exe sub_155AB, 0x24 bytes
+#pragma pack(1)
 struct struc_3 {
     int16 field_0;
     int32 field_2;
     int32 field_6;
     uint8 field_10[26];
 };
-#if !defined(MSDOS) || defined(_MSC_VER) && (_MSC_VER > 510)
-STATIC_ASSERT(sizeof(struct struc_3)==40);
-#else
+#pragma pack()
 STATIC_ASSERT(sizeof(struct struc_3)==36);
-#endif
 
 // used in egame.exe, 0x10 bytes
 struct struc_4 {
@@ -310,7 +308,7 @@ struct PageDesc {
     int16 *selfPtr;     /* +0x16: pointer to start of this struct (pageNum field) */
 };
 #pragma pack()
-STATIC_ASSERT(sizeof(struct PageDesc)==24);
+STATIC_ASSERT(sizeof(struct PageDesc) == 22 + sizeof(void*));
 
 #pragma pack(1)
 struct Matrix3dEntry7 {


### PR DESCRIPTION
Introduce compat64 shim headers (dos.h, bios.h, conio.h) that stub out DOS-specific APIs for modern compilers. Update headers to use `defined(MSDOS)` consistently instead of `defined(__MSDOS__)`, fix struct size assertions to be pointer-size-aware, and add missing function stubs for non-DOS builds.