### PR TITLE
Add NO_ASM build implementation with gfx trampoline layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,13 @@ set(SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Virtual-overlay gfx trampolines: start/end/egame far-call into f15.exe's
+# gfx_impl.c at runtime. f15 itself links gfx_impl.c directly instead.
+set(NOASM_GFX_SOURCES
+    ${SRC_DIR}/slottram.c
+    ${SRC_DIR}/ovlpatch.c
+)
+
 set(SHARED_SOURCES
     ${SRC_DIR}/shared/file_io.c
     ${SRC_DIR}/shared/gfxstub.c
@@ -32,8 +39,8 @@ set(START_SOURCES
     ${SRC_DIR}/stgrid.c
     ${SRC_DIR}/stgen.c
     ${SRC_DIR}/stdata.c
-    ${SRC_DIR}/gfx_impl.c
     ${SHARED_SOURCES}
+    ${NOASM_GFX_SOURCES}
 )
 
 set(EGAME_SOURCES
@@ -56,7 +63,7 @@ set(EGAME_SOURCES
     ${SRC_DIR}/egfileio.c
     ${SRC_DIR}/egpic.c
     ${SRC_DIR}/egstubs.c
-    ${SRC_DIR}/gfx_impl.c
+    ${NOASM_GFX_SOURCES}
 )
 
 set(END_SOURCES
@@ -69,8 +76,8 @@ set(END_SOURCES
     ${SRC_DIR}/endbrf.c
     ${SRC_DIR}/enfile.c
     ${SRC_DIR}/end_data.c
-    ${SRC_DIR}/gfx_impl.c
     ${SHARED_SOURCES}
+    ${NOASM_GFX_SOURCES}
 )
 
 set(F15_SOURCES
@@ -80,6 +87,8 @@ set(F15_SOURCES
     ${SRC_DIR}/output.c
     ${SRC_DIR}/overlay.c
     ${SRC_DIR}/f15util.c
+    ${SRC_DIR}/gfx_impl.c
+    ${SRC_DIR}/compat64/gfx_regshim.c
 )
 
 add_executable(f15 ${F15_SOURCES})

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ HDRS := $(addprefix $(SRCDIR)/,$(HDRFILES))
 asmobj = $(addprefix $(1)/,$(2:.asm=.obj))
 cobj = $(addprefix $(1)/,$(2:.c=.obj))
 
-.PHONY: f15-se2 clean f15-se2-test verify verify-debug verify-start test reasm start-gen-asm start hello debug debug-start debug-end debug-egame tools noasm-start
+.PHONY: f15-se2 clean f15-se2-test verify verify-debug verify-start test reasm start-gen-asm start hello debug debug-start debug-end debug-egame tools noasm-start noasm-f15
 all: f15-se2
 
 #
@@ -115,7 +115,7 @@ $(START_EXE): $(START_OBJ)
 # start.exe debug build
 START_DEBUG := $(DEBUGDIR)/start.exe
 $(START_DEBUG): MSC_CFLAGS += /DDEBUG
-$(DEBUGDIR)/stmain.obj: MSC_CFLAGS := /Gs /Zi /Id:\f15-se2 /DDEBUG /DDEBUG_AUTOSTART
+$(DEBUGDIR)/stmain.obj: MSC_CFLAGS := /Gs /Zi /Id:\f15-se2 /DDEBUG
 START_DBG_OBJ := $(call cobj,$(DEBUGDIR),$(START_SRC)) $(call asmobj,$(DEBUGDIR),$(START_ASM)) $(DEBUGDIR)/util.obj $(DEBUGDIR)/util2.obj $(DEBUGDIR)/debug.obj
 $(START_DBG_OBJ): $(START_BASEHDR)
 $(START_DBG_OBJ): ASMFLAGS += -DDEBUG
@@ -128,11 +128,11 @@ $(START_DEBUG): $(DEBUGDIR) $(START_DBG_OBJ)
 	fi
 
 #
-# start.exe NO_ASM build (pure C graphics, no overlay needed)
+# start.exe NO_ASM build
 #
 NOASMDIR := noasm_build
 START_NOASM := $(NOASMDIR)/start.exe
-NOASM_SRC := $(START_SRC) gfx_impl.c
+NOASM_SRC := $(START_SRC) slottram.c ovlpatch.c
 NOASM_SHARED_SRC := file_io.c timer.c miscstub.c gfxstub.c picstub.c ovlstub.c
 NOASM_COBJ := $(call cobj,$(NOASMDIR),$(NOASM_SRC)) $(addprefix $(NOASMDIR)/,$(NOASM_SHARED_SRC:.c=.obj))
 NOASM_OBJ := $(NOASM_COBJ) $(NOASMDIR)/util.obj $(NOASMDIR)/util2.obj
@@ -151,6 +151,21 @@ $(START_NOASM): $(NOASM_OBJ)
 		ls -l $(F15_TESTDIR)/start.exe; \
 	fi
 
+#
+# f15.exe NO_ASM build (virtual gfx overlay — no Mgraphic.exe required)
+#
+F15_NOASM := $(NOASMDIR)/f15.exe
+NOASM_F15_SRC := f15.c dosfunc.c biosfunc.c output.c overlay.c f15util.c gfx_impl.c
+NOASM_F15_COBJ := $(call cobj,$(NOASMDIR),$(NOASM_F15_SRC))
+# regshim.asm: register-call ABI glue for the register-passed gfx slots
+NOASM_F15_OBJ := $(NOASM_F15_COBJ) $(NOASMDIR)/regshim.obj
+$(NOASM_F15_COBJ): MSC_CFLAGS := /Gs /Zi /Id:\f15-se2 /DNO_ASM /DBUGFIX
+$(F15_NOASM): | $(NOASMDIR)
+$(F15_NOASM): $(NOASM_F15_OBJ)
+	@$(DOSBUILD) link $(LINK_TOOLCHAIN) -i $(NOASM_F15_OBJ) -o $@ -f "$(LINKFLAGS)"
+
+noasm-f15: $(F15_NOASM)
+
 $(NOASMDIR):
 	mkdir -p $@
 
@@ -162,6 +177,20 @@ $(NOASMDIR)/%.obj: $(SRCDIR)/shared/%.c $(HDRS) | $(NOASMDIR)
 
 $(NOASMDIR)/%.obj: $(SRCDIR)/%.asm | $(NOASMDIR)
 	$(ASM) $(ASMFLAGS) -Fo$@ $<
+
+#
+# egame.exe NO_ASM build (virtual gfx overlay - Phase 3 of plan)
+#
+EGAME_NOASM := $(NOASMDIR)/egame.exe
+NOASM_EGAME_SRC := egmain.c eg3d_a.c eg3d_b.c eg3d_c.c eg3d_d.c eg3d_e.c eg3d_f.c eg3d_g.c eghud.c eghud_g.c egflight.c egtacmap.c egui.c egwaypt.c egmath.c egweap.c egfileio.c egpic.c slottram.c ovlpatch.c
+EGAME_NOASM_COBJ := $(call cobj,$(NOASMDIR),$(EGAME_NOASM_SRC))
+EGAME_NOASM_OBJ := $(EGAME_NOASM_COBJ) $(NOASMDIR)/util.obj $(NOASMDIR)/util2.obj
+$(EGAME_NOASM_COBJ): MSC_CFLAGS := /Gs /Zi /Id:\f15-se2 /DNO_ASM /DBUGFIX
+$(EGAME_NOASM): | $(NOASMDIR)
+$(EGAME_NOASM): $(EGAME_NOASM_OBJ)
+	@$(DOSBUILD) link $(LINK_TOOLCHAIN) -i $(EGAME_NOASM_OBJ) -o $@ -f "$(LINKFLAGS)" -l "slibce.lib"
+
+noasm-egame: $(EGAME_NOASM)
 
 noasm-start: $(START_NOASM)
 
@@ -276,10 +305,10 @@ $(END_DEBUG): $(DEBUGDIR) $(END_DBG_OBJ)
 	fi
 
 #
-# end.exe NO_ASM build (pure C graphics, no overlay needed)
+# end.exe NO_ASM build
 #
 END_NOASM := $(NOASMDIR)/end.exe
-NOASM_END_SRC := $(END_SRC) gfx_impl.c
+NOASM_END_SRC := $(END_SRC) slottram.c ovlpatch.c
 NOASM_END_COBJ := $(call cobj,$(NOASMDIR),$(NOASM_END_SRC)) $(addprefix $(NOASMDIR)/,$(NOASM_SHARED_SRC:.c=.obj))
 NOASM_END_OBJ := $(NOASM_END_COBJ) $(NOASMDIR)/util.obj $(NOASMDIR)/util2.obj
 $(NOASM_END_COBJ): $(END_BASEHDR)

--- a/src/compat64/gfx_regshim.c
+++ b/src/compat64/gfx_regshim.c
@@ -1,0 +1,59 @@
+/*
+ * gfx_regshim.c — native/64-bit replacement for regshim.asm.
+ *
+ * In the DOS f15.exe build, ten gfx slots are register-call shims written in
+ * regshim.asm: the overlay engine invokes them with arguments in registers,
+ * and the asm glue marshals those into a normal cdecl call to the matching
+ * gfx_*_impl() body in gfx_impl.c. The 64-bit build has no asm, so the public
+ * symbols those shims export (gfx_setPage1, gfx_clearPage, ...) would be
+ * undefined at link time.
+ *
+ * fillSlotTable() in gfx_impl.c takes the address of each public symbol and
+ * casts it to GfxSlotFn (int(*)(void)); the slot.h prototypes are all `()`
+ * (= (void) under C++), so that cast resolves to the (void) overload. We
+ * provide exactly those (void) symbols here. The bodies forward to the
+ * gfx_*_impl() functions — the 64-bit build only links/lints, it never runs
+ * the overlay, so the dummy zero arguments are inconsequential.
+ *
+ * A handful of getter slots (gfx_getDisplayPage/fontSetup/getVal/getVal2) are
+ * defined in gfx_impl.c with argument-taking signatures that likewise don't
+ * match slot.h's `()` prototype; fillSlotTable selects the (void) overload for
+ * them too, so they are provided here as well.
+ */
+
+#include "inttype.h"
+#include "pointers.h"
+#include "slot.h"
+
+#if !defined(MSDOS)
+
+/* register-call shim bodies (cdecl) live in gfx_impl.c */
+extern void gfx_clearPage_impl(uint16 seg);
+extern void gfx_setCurPageSeg_impl(uint16 seg);
+extern int  gfx_getRowOffset_impl(int y);
+extern int  gfx_getPageSeg_impl(uint16 page);
+extern void gfx_fillRow_impl(uint16 rowOffset, uint16 srcBuf, uint16 rowNum);
+extern void gfx_copyRow_impl(uint16 rowOffset);
+extern int  gfx_setPage1_impl(uint16 page);
+extern int  gfx_getCurPageSeg2_impl(void);
+extern void gfx_setFillColor_impl(uint16 color);
+extern void gfx_dirtyRectFill_impl(uint16 minBufOff, uint16 yMin, uint16 yMax);
+
+int FAR CDECL gfx_clearPage(void)      { gfx_clearPage_impl(0); return 0; }
+int FAR CDECL gfx_getCurPageSeg(void)  { gfx_setCurPageSeg_impl(0); return 0; }
+int FAR CDECL gfx_getRowOffset(void)   { return gfx_getRowOffset_impl(0); }
+int FAR CDECL gfx_getPageSeg(void)     { return gfx_getPageSeg_impl(0); }
+int FAR CDECL gfx_fillRow(void)        { gfx_fillRow_impl(0, 0, 0); return 0; }
+int FAR CDECL gfx_copyRow(void)        { gfx_copyRow_impl(0); return 0; }
+int FAR CDECL gfx_setPage1(void)       { return gfx_setPage1_impl(0); }
+int FAR CDECL gfx_getCurPageSeg2(void) { return gfx_getCurPageSeg2_impl(); }
+int FAR CDECL gfx_setPageDirect(void)  { gfx_setFillColor_impl(0); return 0; }
+int FAR CDECL gfx_dirtyRect2(void)     { gfx_dirtyRectFill_impl(0, 0, 0); return 0; }
+
+/* getter slots whose gfx_impl.c definitions take args (no (void) overload) */
+int FAR CDECL gfx_getDisplayPage(void) { return 0; }
+int FAR CDECL gfx_fontSetup(void)      { return 0; }
+int FAR CDECL gfx_getVal(void)         { return 0; }
+int FAR CDECL gfx_getVal2(void)        { return 0; }
+
+#endif /* !MSDOS */

--- a/src/f15.c
+++ b/src/f15.c
@@ -24,6 +24,10 @@
 #include "overlay.h"
 #include "f15util.h"
 #include "offsets.h"
+#ifdef NO_ASM
+#include "gfx_impl.h"
+#include "slot.h"
+#endif
 
 #include <stdio.h>
 #include <stddef.h>
@@ -46,6 +50,11 @@ enum { CMDLINE_LEN = 128 };
 char cmdlineBuf[CMDLINE_LEN] = "";
 const char FAR *CMDLINE = (const char FAR*)cmdlineBuf;
 uint16 commSegment = 0;
+#ifdef NO_ASM
+/* Satisfy linker for gfx_drawLine's extern refs when stdata.c is absent.
+ * At runtime these live in the calling exe's data segment (correct behavior). */
+int16 lineX1, lineX2, lineY1, lineY2;
+#endif
 
 uint16 load_driver(const char* filename, const uint16 commPtrOffset) {
     /* load driver overlay into memory */
@@ -64,18 +73,21 @@ uint16 load_driver(const char* filename, const uint16 commPtrOffset) {
 void game_init(void) {
     size_t freeMemory;
     int8 FAR *charPtr;
-    OverlayFunc gfxInit = NULL;
-    uint16 gfxDrvAddress, gfxBufAddress;
+    uint16 gfxBufAddress;
     int err;
-    
+#ifndef NO_ASM
+    OverlayFunc gfxInit = NULL;
+    uint16 gfxDrvAddress;
+#endif
+
     bios_clearkeyflags();
 
     /* get amount of free memory */
     freeMemory = dos_getfree();
-    if (freeMemory == 0) 
+    if (freeMemory == 0)
         FATAL("Unable to get amount of free memory!");
     INFO("free memory: %s", sizeString(freeMemory));
-    
+
     /* allocate memory for communication buffer between game executables */
     commSegment = dos_alloc(COMM_SIZE_PARA);
     if (commSegment == 0)
@@ -85,7 +97,7 @@ void game_init(void) {
     writeWordFar(commSegment - 1, COMM_MCB_OFFSET_MAGIC1, COMM_MCB_VALUE_MAGIC1);
     writeWordFar(commSegment - 1, COMM_MCB_OFFSET_MAGIC2, COMM_MCB_VALUE_MAGIC2);
 
-    /* put address of communication buffer into the Intra-Application Comunication Area in low memory 
+    /* put address of communication buffer into the Intra-Application Comunication Area in low memory
        so that all game executables can find out where it is */
     writeWordFar(SEG_LOWMEM, OFF_IACA_START, commSegment);
     writeWordFar(SEG_LOWMEM, OFF_IACA_NEEDSPLASH, 1);
@@ -97,11 +109,15 @@ void game_init(void) {
     writeWordFar(commSegment, COMM_SETUP2_OFFSET, 0);
     writeWordFar(commSegment, COMM_SETUP_DETAIL_OFFSET, 3); /* max detail */
     writeWordFar(commSegment, COMM_SETUP_USEJOY_OFFSET, 0);
+#ifndef NO_ASM
     strcpyFar(GFX_DRIVER, commSegment, COMM_GFXOVL_NAME_OFFSET, strlen(GFX_DRIVER));
+#endif
+    /* sound driver name is read by start.exe (PC-speaker check) in both builds */
     strcpyFar(SOUND_DRIVER, commSegment, COMM_SNDOVL_NAME_OFFSET, strlen(SOUND_DRIVER));
     writeWordFar(commSegment, COMM_SETUP_DONE_OFFSET, 1);
     writeWordFar(commSegment, COMM_SETUP_GFXMODE_OFFSET, (uint16)'M'); /* mcga */
 
+#ifndef NO_ASM
     /* load sound, misc and video driver overlays */
     load_driver(SOUND_DRIVER, COMM_SNDOVL_ADDR_OFFSET);
     load_driver(MISC_LIBRARY, COMM_MISCOVL_ADDR_OFFSET);
@@ -112,6 +128,35 @@ void game_init(void) {
     INFO("gfx init function at %p", gfxInit);
     gfxBufAddress = gfxInit(GFX_INIT_ARG);
     INFO("gfx init function returned 0x%x", gfxBufAddress);
+#else
+    {
+        uint16 ovlSeg = dos_alloc(80);
+        uint16 sndSeg, miscSeg;
+        if (ovlSeg == 0)
+            FATAL("Unable to allocate virtual gfx overlay");
+        gfx_buildVirtualOverlay(ovlSeg);
+        writeWordFar(commSegment, COMM_GFXOVL_ADDR_OFFSET, ovlSeg);
+        INFO("Virtual gfx overlay at 0x%x", ovlSeg);
+
+        /* Stub SOUND and MISC overlays provided by f15.exe itself — no
+         * NSOUND.EXE / MISC.EXE on disk. An ASM child still patches its
+         * audio/misc slots from these (otherwise the unpatched JMP FAR
+         * 0000:0000 stubs crash); NO_ASM children ignore them (their misc
+         * is direct C and the slot index range is out of their gfx table). */
+        sndSeg = dos_alloc(4);
+        miscSeg = dos_alloc(4);
+        if (sndSeg == 0 || miscSeg == 0)
+            FATAL("Unable to allocate stub misc/sound overlays");
+        gfx_buildSoundOverlay(sndSeg);
+        gfx_buildMiscOverlay(miscSeg);
+        writeWordFar(commSegment, COMM_SNDOVL_ADDR_OFFSET, sndSeg);
+        writeWordFar(commSegment, COMM_MISCOVL_ADDR_OFFSET, miscSeg);
+        INFO("Stub sound overlay at 0x%x, misc overlay at 0x%x", sndSeg, miscSeg);
+
+        gfxBufAddress = (uint16)gfx_allocPage((int)GFX_INIT_ARG);
+        INFO("gfx_allocPage returned 0x%x", gfxBufAddress);
+    }
+#endif
     writeWordFar(commSegment, COMM_GFXINIT_RESULT_OFFSET, gfxBufAddress);
 
     /* initialization done */

--- a/src/gfx_impl.c
+++ b/src/gfx_impl.c
@@ -6,53 +6,58 @@
 #include "struct.h"
 #include "slot.h"
 #include <dos.h>
-#include <string.h>
+#include <stdio.h>
 
-#ifndef NULL
-#define NULL ((void*)0)
-#endif
+#include "fontdata.h"
 
 /* dos_alloc is provided by lowlvl.asm (start.exe) or dosfunc.c (f15.exe) */
 extern uint16 dos_alloc(uint16 size);
 
-#include "fontdata.h"
+/* File-scope object used only for its address: FP_SEG of its far pointer
+ * yields f15.exe's DGROUP segment, recorded in GfxState.f15DataSeg so the
+ * const tables below (palettes, font tables) can be reached via far pointer
+ * regardless of which process's DS is current at call time (Finding A). */
+static int dgroupAnchor;
 
-/* movedata(src_seg, src_off, dst_seg, dst_off, count) from <memory.h>/<string.h>
- * is the closest thing to memcpy() for far memory in MSC 5.1.
- * It uses rep movsw internally. We use it directly everywhere.
+/* Byte offset of GfxState within the virtual overlay block */
+#define GFX_STATE_OFFSET 0x2EC
+
+/* Constants for IACA/COMM access */
+#define SEG_LOWMEM 0
+#define OFF_IACA_START 0x4f0
+#define COMM_GFXOVL_ADDR_OFFSET 0x1a
+
+/**
+ * @brief Retrieves a far pointer to the shared GfxState structure in the virtual overlay.
+ * This function must be called by all gfx functions needing access to shared state.
  */
-
-/* ---- Internal state (replaces cs: and ds: overlay variables) ---- */
-
-static uint16 g_rowOffsets[200];        /* cs:0x0e - precomputed row*320 */
-static uint16 g_curPageSeg;             /* cs:0x19e */
-static uint16 g_blitOffset;             /* cs:0x1a0 */
-static uint8  g_modeFlag = 1;           /* cs:0x1a2 */
-static uint16 g_pageSegs[16];           /* cs:0x681 */
-static uint8  g_fillColor;              /* ds:0x1b7a */
-static uint8  g_dacCounter;             /* cs:0x9b2 */
-static uint8  g_rowOffsetsReady = 0;
+static GfxState FAR *gfx_getState(void) {
+    uint16 commSeg = *(uint16 FAR *)MK_FP(SEG_LOWMEM, OFF_IACA_START);
+    uint16 ovlSeg  = *(uint16 FAR *)MK_FP(commSeg, COMM_GFXOVL_ADDR_OFFSET);
+    return (GfxState FAR *)MK_FP(ovlSeg, GFX_STATE_OFFSET);
+}
 
 /* Initialize row offset table */
 static void initRowOffsets(void)
 {
     int i;
-    if (g_rowOffsetsReady) return;
+    if (gfx_getState()->rowOffsetsReady) return;
     for (i = 0; i < 200; i++)
-        g_rowOffsets[i] = (uint16)(i * 320);
-    g_rowOffsetsReady = 1;
+        gfx_getState()->rowOffsets[i] = (uint16)(i * 320);
+    gfx_getState()->rowOffsetsReady = 1;
 }
 
 /* ---- Slot 0x00: gfx_allocPage ---- */
-int FAR CDECL gfx_allocPage(int pageNum)
+int FAR CDECL gfx_allocPage(int n)
 {
+    GfxState FAR *s;
     uint16 seg;
     union REGS r;
     initRowOffsets();
     /* In the original game, the MGRAPHIC overlay persists across exes and
      * gfx_setMode13 was already called by start.exe. In our NO_ASM build,
      * each exe has fresh static state. Bootstrap mode 13h on first use. */
-    if (g_pageSegs[0] == 0) {
+    if (gfx_getState()->pageSegs[0] == 0) {
         gfx_setMode13(0);
     }
     /* Allocate 0x1000 paragraphs = 64KB directly via INT 21h */
@@ -60,12 +65,11 @@ int FAR CDECL gfx_allocPage(int pageNum)
     r.x.bx = 0x1000;
     intdos(&r, &r);
     seg = r.x.cflag ? 0 : r.x.ax;
-    if (seg == 0) return 0;
     /* Don't overwrite page 0 if it's already the VGA framebuffer.
      * end.exe draws directly to 0xA000; gfx_setPageN(0) must keep
      * returning 0xA000 so all rendering is immediately visible. */
-    if (pageNum != 0 || g_pageSegs[0] != 0xA000) {
-        g_pageSegs[pageNum] = seg;
+    if (n != 0 || gfx_getState()->pageSegs[0] != 0xA000) {
+        gfx_getState()->pageSegs[n] = seg;
     }
     return (int)seg;
 }
@@ -74,10 +78,21 @@ int FAR CDECL gfx_allocPage(int pageNum)
 int FAR CDECL gfx_setMode13(int16 monoFlag)
 {
     union REGS regs;
+    GfxState FAR *s; /* Declare at function level for MSC small model */
 
     (void)monoFlag;
 
     initRowOffsets();
+
+    /* Disable VGA gray-scale summing (INT 10h AH=12h AL=01h BL=33h) before the
+     * mode set. Real MGRAPHIC's slot 0 only allocates, so the child sets mode
+     * 13h exactly once; our NO_ASM parent calls gfx_setMode13 during
+     * gfx_allocPage, and in that path the BIOS sums the default EGA palette to
+     * luminance (logo/adv render gray). Disabling summing makes the subsequent
+     * mode set load the colour default palette. */
+    regs.x.ax = 0x1201;
+    regs.x.bx = 0x0033;
+    int86(0x10, &regs, &regs);
 
     /* Set video mode 13h */
     regs.x.ax = 0x0013;
@@ -89,10 +104,10 @@ int FAR CDECL gfx_setMode13(int16 monoFlag)
     if (regs.h.al != 0x13) return -1;
 
     /* Clear page 0 (VGA framebuffer) */
-    g_pageSegs[0] = 0xA000;
-    g_curPageSeg = g_pageSegs[1]; /* default to back buffer */
-    g_modeFlag = 1;
-
+    s = gfx_getState();
+    s->pageSegs[0] = 0xA000;
+    s->curPageSeg = s->pageSegs[1]; /* default to back buffer */
+    s->modeFlag = 1;
 
     return 0;
 }
@@ -110,49 +125,71 @@ int FAR CDECL gfx_waitRetrace(void)
 /* ---- Slot 0x46: gfx_flipPage ---- */
 int FAR CDECL gfx_flipPage(void)
 {
-    /* In the original MGRAPHIC overlay, this is just a retrace wait +
-     * CRT register tweak. It does NOT copy memory. end.exe draws
-     * directly to 0xA000 (curPageSeg = VGA framebuffer). */
+    /* The original MGRAPHIC slot 0x46 waits for retrace then un-blanks the
+     * display (sequencer reg 1 bit 5 cleared); the companion gfx_waitRetrace
+     * (slot 0x45) blanks it. It does NOT copy video memory — the game draws
+     * directly to the visible page (0xA000). An earlier version copied
+     * curPageSeg->0xA000 here, which blacked screens (e.g. the pilot roster)
+     * whenever curPageSeg was left pointing at an off-screen work buffer by a
+     * preceding sprite blit. Just sync to retrace. */
     gfx_waitRetrace();
-    if (g_curPageSeg != 0xA000) {
-        movedata(g_curPageSeg, 0, 0xA000, 0, 64000u);
-    }
     return 0;
 }
 
 /* ---- Slot 0x4b: gfx_storeBufPtr ---- */
 int FAR CDECL gfx_storeBufPtr(uint16 seg, int pageIdx)
 {
-    g_pageSegs[pageIdx] = seg;
+    GfxState FAR *s = gfx_getState();
+    if (pageIdx >= 0 && pageIdx < 16) {
+        s->pageSegs[pageIdx] = seg;
+    }
     return 0;
 }
 
-/* ---- Slot 0x3b: gfx_clearPage ---- */
-int FAR CDECL gfx_clearPage(void)
+/* ---- Slot 0x3b: gfx_clearPage ----
+ * Register-called via the _gfx_clearPage asm shim (regshim.asm): the caller
+ * passes the target segment in ES (decodePic sets it directly, showPicFile via
+ * _gfx_getPageSeg). The shim pushes ES as `seg`. We record it as curPageSeg so
+ * the subsequent fillRow/fillRow2 (which write curPageSeg) land in this buffer,
+ * then clear it — matching MGRAPHIC's slot 0x3b (`rep stosw` to ES:0). */
+void gfx_clearPage_impl(uint16 seg)
 {
-    uint8 far *p = (uint8 far *)MK_FP(g_curPageSeg, 0);
+    GfxState FAR *s = gfx_getState();
+    uint8 far *p;
     uint16 i;
+    s->curPageSeg = seg;
+    p = (uint8 far *)MK_FP(seg, 0);
     /* Clear 64000 bytes (32000 words) */
     for (i = 0; i < 32000u; i++) {
         ((uint16 far *)p)[i] = 0;
     }
-    return 0;
 }
 
 /* ---- Slot 0x0e: gfx_setPageN ---- */
 int FAR CDECL gfx_setPageN(uint16 pageNum)
 {
-    if (g_pageSegs[0] == 0) {
+    GfxState FAR *s = gfx_getState();
+    /* Don't re-init mode if page 0 is VGA framebuffer */
+    if (s->pageSegs[0] == 0xA000) {
+        s->curPageSeg = s->pageSegs[pageNum];
+        return 0;
+    }
+    initRowOffsets();
+    /* Bootstrap mode 13h for first use */
+    if (s->pageSegs[0] == 0) {
         gfx_setMode13(0);
     }
-    g_curPageSeg = g_pageSegs[pageNum];
+    s->curPageSeg = s->pageSegs[pageNum];
     return 0;
 }
 
 /* ---- Slot 0x0f: gfx_getCurPageSeg ---- */
-int FAR CDECL gfx_getCurPageSeg(void)
+/* Slot 0x0f: register-called via the _gfx_getCurPageSeg shim — AX = segment;
+ * curPageSeg = AX. MGRAPHIC's slot 0x0f is `mov [curPageSeg],ax` — a SETTER (the
+ * getter is slot 0x10). clearRect saves curPageSeg via 0x10 and restores it here. */
+void gfx_setCurPageSeg_impl(uint16 seg)
 {
-    return (int)g_curPageSeg;
+    gfx_getState()->curPageSeg = seg;
 }
 
 /* ---- Slot 0x17: gfx_getBufSize ---- */
@@ -161,40 +198,70 @@ int FAR CDECL gfx_getBufSize(void)
     return 0x5580; /* 21888 bytes — sprite buffer size (matches real overlay) */
 }
 
-/* ---- Slot 0x3a: gfx_getRowOffset ---- */
-/* Note: register-called in overlay (y in DI). Stub for NO_ASM. */
-int FAR CDECL gfx_getRowOffset(void)
+/* ---- Slots 0x3a/0x38/0x33/0x35: register-called by the ASM pic renderer ----
+ * The overlay slot symbols (gfx_getRowOffset/gfx_getPageSeg/gfx_fillRow/
+ * gfx_copyRow) are tiny asm shims in regshim.asm that marshal the register
+ * args (DI/SI/BP/BX) into cdecl stack args and call these *_impl bodies. DS is
+ * the caller's DGROUP throughout, so `srcBuf` is read as a near pointer. */
+
+/* Slot 0x3a: DI = y -> AX = row byte offset (y*320). */
+int gfx_getRowOffset_impl(int y)
 {
-    /* TODO: need register-call wrapper or rework callers */
-    return 0;
+    GfxState FAR *s = gfx_getState();
+    initRowOffsets();
+    if (y >= 0 && y < 200)
+        return (int)s->rowOffsets[y];
+    return (int)((uint16)y * 320);
 }
 
-/* ---- Slot 0x38: gfx_getPageSeg ---- */
-/* Note: register-called in overlay. Stub for NO_ASM. */
-int FAR CDECL gfx_getPageSeg(void)
+/* Slot 0x38: SI = page -> select it as current page, return its segment. */
+int gfx_getPageSeg_impl(uint16 page)
 {
-    /* TODO: need register-call wrapper or rework callers */
-    return 0;
+    GfxState FAR *s = gfx_getState();
+    if (page < 16)
+        s->curPageSeg = s->pageSegs[page];
+    return (int)s->curPageSeg;
+}
+
+/* Slot 0x33: DI = rowOffset, BP = srcBuf (caller DS), BX = rowNum.
+ * Copy one 320-byte decoded row into the current page (MCGA: direct write). */
+void gfx_fillRow_impl(uint16 rowOffset, uint16 srcBuf, uint16 rowNum)
+{
+    GfxState FAR *s = gfx_getState();
+    const uint8 *src = (const uint8 *)srcBuf;          /* near ptr, caller's DS */
+    uint8 FAR *dst = (uint8 FAR *)MK_FP(s->curPageSeg, rowOffset);
+    int i;
+    (void)rowNum;
+    for (i = 0; i < 320; i++)
+        dst[i] = src[i];
+}
+
+/* Slot 0x35: DI = rowOffset. In MCGA the row is already in the page (fillRow
+ * wrote directly), so this is a no-op. */
+void gfx_copyRow_impl(uint16 rowOffset)
+{
+    (void)rowOffset;
 }
 
 /* ---- Slot 0x3f: gfx_getModecode ---- */
 int FAR CDECL gfx_getModecode(void)
 {
-
     return 3; /* MCGA mode code */
 }
 
-/* ---- Slot 0x22: gfx_resetBlitOffset ---- */
+/* ---- Slot 0x1a0: gfx_resetBlitOffset ---- */
 int FAR CDECL gfx_resetBlitOffset(void)
 {
-    g_blitOffset = 0;
+    GfxState FAR *s = gfx_getState();
+    s->blitOffset = 0;
     return 0;
 }
 
 /* ---- Slot 0x1a: gfx_setBlitOffset ---- */
 int FAR CDECL gfx_setBlitOffset(int offset)
 {
-    g_blitOffset = (uint16)offset;
+    GfxState FAR *s = gfx_getState();
+    s->blitOffset = (uint16)offset;
     return 0;
 }
 
@@ -249,6 +316,12 @@ static uint8 g_fontBitmapRowSize[8] = {0, 8, 0, 6, 7, 6, 0, 0};
 /* ---- Slot 0x05: gfx_drawString ---- */
 int FAR CDECL gfx_drawString(int16 *pageNum, const char *string)
 {
+    GfxState FAR *s = gfx_getState();
+    uint16 dseg;
+    uint8 FAR *heightsFar;
+    uint8 FAR *rowSizeFar;
+    uint8 * FAR *bmpPtrsFar;
+    uint8 * FAR *wtPtrsFar;
     uint16 x, y, color;
     uint8 far *page;
     int i;
@@ -256,22 +329,37 @@ int FAR CDECL gfx_drawString(int16 *pageNum, const char *string)
     int row, col;
     uint16 fontIdx;
     uint8 height;
-    uint8 *bitmaps;
-    uint8 *wt;
+    uint8 FAR *bitmaps;
+    uint8 FAR *wt;
 
-    if (!string) return 0;
+    if (!string || !pageNum) return 0;
+
+    /* The font tables live in f15's DGROUP. When a child far-calls in, DS is
+     * the child's DGROUP (no font data there), so reach the tables via
+     * f15DataSeg (Finding A). The g_fontBitmapPtrs / g_fontWidthTables ENTRIES
+     * are themselves near offsets into f15's DGROUP, so each selected entry
+     * must be re-based on f15DataSeg as well before it can be dereferenced. */
+    dseg       = s->f15DataSeg;
+    heightsFar = (uint8 FAR *)MK_FP(dseg, (uint16)g_fontHeightsArr);
+    rowSizeFar = (uint8 FAR *)MK_FP(dseg, (uint16)g_fontBitmapRowSize);
+    bmpPtrsFar = (uint8 * FAR *)MK_FP(dseg, (uint16)g_fontBitmapPtrs);
+    wtPtrsFar  = (uint8 * FAR *)MK_FP(dseg, (uint16)g_fontWidthTables);
 
     x = (uint16)pageNum[4];
     y = (uint16)pageNum[5];
     color = (uint16)pageNum[2];
     fontIdx = (uint16)pageNum[6] & 7;
-    height = g_fontHeightsArr[fontIdx];
-    bitmaps = g_fontBitmapPtrs[fontIdx];
-    wt = g_fontWidthTables[fontIdx];
+    height = heightsFar[fontIdx];
+    bitmaps = bmpPtrsFar[fontIdx]
+        ? (uint8 FAR *)MK_FP(dseg, (uint16)bmpPtrsFar[fontIdx]) : (uint8 FAR *)0;
+    wt = wtPtrsFar[fontIdx]
+        ? (uint8 FAR *)MK_FP(dseg, (uint16)wtPtrsFar[fontIdx]) : (uint8 FAR *)0;
 
-    page = (uint8 far *)MK_FP(g_pageSegs[pageNum[0]], 0);
+    /* pageNum/string are caller-passed NEAR pointers — they correctly resolve
+     * against the caller's DS, so they must NOT be re-based on f15DataSeg. */
+    page = (uint8 far *)MK_FP(s->pageSegs[pageNum[0]], 0);
 
-    for (i = 0; string[i] != '\0'; i++) {
+    for (i = 0; string[i] != 0 && i < 256; i++) {
         ch = (uint8)string[i];
 
         /* Inline color escape: chars >= 0x80 change the text color.
@@ -285,10 +373,10 @@ int FAR CDECL gfx_drawString(int16 *pageNum, const char *string)
         if (y + height > 200) break;
 
         if (bitmaps && ch >= 0x20) {
-            uint8 *glyph = bitmaps + (ch - 0x20) * (uint16)g_fontBitmapRowSize[fontIdx];
+            uint8 FAR *glyph = bitmaps + (ch - 0x20) * (uint16)rowSizeFar[fontIdx];
             for (row = 0; row < height; row++) {
                 uint8 bits = glyph[row];
-                uint16 rowOff = g_rowOffsets[y + row] + x;
+                uint16 rowOff = s->rowOffsets[y + row] + x;
                 for (col = 0; col < 8; col++) {
                     if (bits & 0x80) {
                         page[rowOff + col] = (uint8)color;
@@ -300,8 +388,7 @@ int FAR CDECL gfx_drawString(int16 *pageNum, const char *string)
         x += wt ? (ch >= 0x20 ? wt[ch-0x20] : 8) : 8;
     }
 
-    /* Update x position and color in page struct (the original overlay
-     * writes back the color after inline escape codes modify it) */
+    /* Update x position and color in page struct */
     pageNum[4] = (int16)x;
     pageNum[2] = (int16)color;
     return 0;
@@ -312,12 +399,13 @@ int FAR CDECL gfx_copyRect(int srcPage, uint16 srcX, uint16 srcY,
                             int dstPage, uint16 dstX, uint16 dstY,
                             int width, int height)
 {
+    GfxState FAR *s = gfx_getState();
     int row;
 
     for (row = 0; row < height; row++) {
-        uint16 sOff = g_rowOffsets[srcY + row] + (uint16)srcX;
-        uint16 dOff = g_rowOffsets[dstY + row] + (uint16)dstX;
-        movedata(g_pageSegs[srcPage], sOff, g_pageSegs[dstPage], dOff, (uint16)width);
+        uint16 sOff = s->rowOffsets[srcY + row] + (uint16)srcX;
+        uint16 dOff = s->rowOffsets[dstY + row] + (uint16)dstX;
+        movedata(s->pageSegs[srcPage], sOff, s->pageSegs[dstPage], dOff, (uint16)width);
     }
     return 0;
 }
@@ -333,15 +421,16 @@ int FAR CDECL gfx_blitTransparent(void)
 int FAR CDECL gfx_switchColor(int16 *pageDesc, int x1, int y1,
                                int x2, int y2, int oldColor, int newColor)
 {
+    GfxState FAR *s = gfx_getState();
     uint16 pageSeg;
     uint8 far *page;
     int row, col;
 
-    pageSeg = g_pageSegs[*pageDesc];
+    pageSeg = s->pageSegs[*pageDesc];
     page = (uint8 far *)MK_FP(pageSeg, 0);
 
     for (row = y1; row <= y2; row++) {
-        uint16 off = g_rowOffsets[row];
+        uint16 off = s->rowOffsets[row];
         for (col = x1; col <= x2; col++) {
             if (page[off + col] == (uint8)oldColor)
                 page[off + col] = (uint8)newColor;
@@ -384,18 +473,25 @@ void FAR CDECL gfx_setDac(uint16 palIdx)
 {
     union REGS regs;
     struct SREGS sregs;
+    GfxState FAR *s;
     if (palIdx > 4) return;
     /* INT 10h AX=1012h: set block of DAC color registers */
     regs.x.ax = 0x1012;
     regs.x.bx = 0;       /* first register */
     regs.x.cx = 16;      /* number of registers */
-#if !defined(MSDOS)
-    regs.x.dx = 0; //(uint16)g_palettes[palIdx];
-#else
-    regs.x.dx = (uint16)g_palettes[palIdx];
-#endif
     segread(&sregs);
-    sregs.es = sregs.ds;  /* ES:DX -> palette table */
+#if !defined(MSDOS)
+    (void)s;
+    regs.x.dx = 0; /* (uint16)g_palettes[palIdx]; */
+    sregs.es = sregs.ds;
+#else
+    /* ES:DX -> palette table. DX is the table's offset within f15's DGROUP,
+     * but ES must be f15's DGROUP, NOT the caller's DS: when a child far-calls
+     * in, DS is the child's DGROUP where no palette lives (Finding A). */
+    s = gfx_getState();
+    regs.x.dx = (uint16)g_palettes[palIdx];
+    sregs.es = s->f15DataSeg;
+#endif
     int86x(0x10, &regs, &regs, &sregs);
     gfx_waitRetrace();
 }
@@ -403,17 +499,38 @@ void FAR CDECL gfx_setDac(uint16 palIdx)
 /* ---- Slot 0x21: gfx_setColor ---- */
 int FAR CDECL gfx_setColor(int color)
 {
-    g_fillColor = (uint8)color;
+    GfxState FAR *s = gfx_getState();
+    s->fillColor = (uint8)color;
     return 0;
 }
 
 /* ---- Stubs for remaining slots ---- */
-int FAR CDECL gfx_initOverlay(void) { return 0; }
-int FAR CDECL gfx_setPage1(void) { g_curPageSeg = g_pageSegs[1]; return 0; }
-int FAR CDECL gfx_getCurPageSeg2(void) { return (int)g_curPageSeg; }
-int FAR CDECL gfx_getCurPage(int page) { return (int)g_curPageSeg; }
+int FAR CDECL gfx_initOverlay(void)              { return 0; }
+/* Slot 0x0d: register-called via the _gfx_setPage1 shim (regshim.asm) — AX = a
+ * page index; curPageSeg = pageSegs[AX]. MGRAPHIC's slot 0x0d takes the index in
+ * AX (the name is a misnomer); clearRect uses it to select the page to clear. */
+int gfx_setPage1_impl(uint16 page)
+{
+    GfxState FAR *s = gfx_getState();
+    if (page < 16)
+        s->curPageSeg = s->pageSegs[page];
+    return (int)s->curPageSeg;
+}
+/* Slot 0x10: called via the _gfx_getCurPageSeg2 shim, which preserves ES (a
+ * gfx_getState() call here loads ES, and clearRect needs ES kept across this). */
+int gfx_getCurPageSeg2_impl(void)
+{
+    GfxState FAR *s = gfx_getState();
+    return (int)s->curPageSeg;
+}
+int FAR CDECL gfx_getCurPage(int page)
+{
+    GfxState FAR *s = gfx_getState();
+    return (int)s->pageSegs[page];
+}
 int FAR CDECL gfx_blitSprite(struct SpriteParams *p)
 {
+    GfxState FAR *s = gfx_getState();
     uint16 srcSeg, dstSeg;
     int row, col;
     uint16 srcOff, dstOff;
@@ -422,14 +539,14 @@ int FAR CDECL gfx_blitSprite(struct SpriteParams *p)
 
     if (!p) return 0;
     srcSeg = p->bufPtr;
-    dstSeg = g_pageSegs[p->page];
+    dstSeg = s->pageSegs[p->page];
     w = p->width;
 
     if (!(p->flags & 0x10)) {
         /* Opaque blit — use movedata per row */
         for (row = 0; row < p->height; row++) {
-            srcOff = g_rowOffsets[p->srcY + row] + (uint16)p->srcX;
-            dstOff = g_rowOffsets[p->dstY + row] + (uint16)p->dstX;
+            srcOff = s->rowOffsets[p->srcY + row] + (uint16)p->srcX;
+            dstOff = s->rowOffsets[p->dstY + row] + (uint16)p->dstX;
             movedata(srcSeg, srcOff, dstSeg, dstOff, (uint16)w);
         }
     } else {
@@ -440,8 +557,8 @@ int FAR CDECL gfx_blitSprite(struct SpriteParams *p)
         dsSeg = sr.ds;
         for (row = 0; row < p->height; row++) {
             uint8 far *dst;
-            srcOff = g_rowOffsets[p->srcY + row] + (uint16)p->srcX;
-            dstOff = g_rowOffsets[p->dstY + row] + (uint16)p->dstX;
+            srcOff = s->rowOffsets[p->srcY + row] + (uint16)p->srcX;
+            dstOff = s->rowOffsets[p->dstY + row] + (uint16)p->dstX;
             movedata(srcSeg, srcOff, dsSeg, (uint16)(void near *)rowBuf, (uint16)w);
             dst = (uint8 far *)MK_FP(dstSeg, dstOff);
             for (col = 0; col < w; col++) {
@@ -453,14 +570,14 @@ int FAR CDECL gfx_blitSprite(struct SpriteParams *p)
     }
     return 0;
 }
-int FAR CDECL gfx_drawLine(void)
+int FAR CDECL gfx_drawLine(uint16 x1, uint16 y1, uint16 x2, uint16 y2)
 {
-    /* Bresenham line using lineX1/Y1/X2/Y2 globals, draws to curPageSeg */
-    extern int16 lineX1, lineY1, lineX2, lineY2;
-    uint8 far *page = (uint8 far *)MK_FP(g_curPageSeg, 0);
-    int x0 = lineX1, y0 = lineY1, x1 = lineX2, y1 = lineY2;
-    int dx = x1 - x0;
-    int dy = y1 - y0;
+    GfxState FAR *s = gfx_getState();
+    /* Bresenham line algorithm drawing to current page */
+    uint8 far *page = (uint8 far *)MK_FP(s->curPageSeg, 0);
+    int x0 = x1, y0 = y1, x1_target = x2, y1_target = y2;
+    int dx = x1_target - x0;
+    int dy = y1_target - y0;
     int sx = dx >= 0 ? 1 : -1;
     int sy = dy >= 0 ? 1 : -1;
     int err, e2;
@@ -469,57 +586,138 @@ int FAR CDECL gfx_drawLine(void)
     err = dx - dy;
     for (;;) {
         if ((unsigned)x0 < 320 && (unsigned)y0 < 200)
-            page[g_rowOffsets[y0] + x0] = g_fillColor;
-        if (x0 == x1 && y0 == y1) break;
+            page[s->rowOffsets[y0] + x0] = s->fillColor;
+        if (x0 == x1_target && y0 == y1_target) break;
         e2 = err * 2;
         if (e2 > -dy) { err -= dy; x0 += sx; }
         if (e2 < dx)  { err += dx; y0 += sy; }
     }
     return 0;
 }
-int FAR CDECL gfx_setPageDirect(void) { return 0; }
-int FAR CDECL gfx_resetBlitOffset2(void) { g_blitOffset = 0; return 0; }
-int FAR CDECL gfx_dirtyRect2(void) { return 0; }
-int FAR CDECL gfx_getDisplayPage(void) { return 0; }
+/* Slot 0x20: register-called via the _gfx_setPageDirect shim — AH = fill colour.
+ * Stores the clearRect/fill colour (MGRAPHIC slot 0x20 = `mov [fillColor],ah`). */
+void gfx_setFillColor_impl(uint16 color)
+{
+    gfx_getState()->fillColor = (uint8)color;
+}
+int FAR CDECL gfx_resetBlitOffset2(void) { return 0; }
+/* Slot 0x25/0x28: register-called via the _gfx_dirtyRect2 shim — BX = near offset
+ * of the per-row dirtyMinBuf (in the caller's DS), AX = yMin, CX = yMax. The
+ * matching dirtyMaxBuf sits 0x1b8 bytes after dirtyMinBuf. For each row y in
+ * [yMin..yMax] fill the span [minBuf[y]..maxBuf[y]] of curPageSeg with fillColor.
+ * This is the actual rectangle clear behind clearRect (MGRAPHIC slot 0x25==0x28).
+ * A row whose min==max==0 or ==0x13F is treated as empty and skipped, matching
+ * the original's range guard. */
+void gfx_dirtyRectFill_impl(uint16 minBufOff, uint16 yMin, uint16 yMax)
+{
+    GfxState FAR *s = gfx_getState();
+    const uint16 *minBuf = (const uint16 *)minBufOff;            /* caller's DS */
+    const uint16 *maxBuf = (const uint16 *)(minBufOff + 0x1b8);
+    uint8 fill = s->fillColor;
+    uint16 seg = s->curPageSeg;
+    int y;
+    if ((int16)yMin < 0) return;
+    for (y = (int)yMax; y >= (int)yMin; y--) {
+        uint16 minx = minBuf[y];
+        uint16 maxx = maxBuf[y];
+        uint16 width, col;
+        uint8 far *dst;
+        if (maxx < minx) continue;
+        if (maxx == minx && (maxx == 0 || maxx == 0x13f)) continue;
+        width = maxx - minx + 1;
+        dst = (uint8 far *)MK_FP(seg, s->rowOffsets[y] + s->blitOffset + minx);
+        for (col = 0; col < width; col++)
+            dst[col] = fill;
+    }
+}
+int FAR CDECL gfx_getDisplayPage(uint16 page)
+{
+    GfxState FAR *s = gfx_getState();
+    return (int)s->pageSegs[page];
+}
 
 int FAR CDECL gfx_setFont(uint16 ch, uint16 fontIdx)
 {
-    uint8 *widths;
+    /* Returns the pixel advance width of a single character. stringWidth()
+     * sums this over a string to centre text, so it MUST agree with the
+     * x-advance gfx_drawString uses (wt[ch-0x20]); otherwise centred text
+     * lands off-screen and drawString's clip test discards every glyph.
+     * The width tables live in f15's DGROUP, reached via f15DataSeg (Finding A),
+     * exactly as gfx_drawString rebases them. */
+    GfxState FAR *s = gfx_getState();
+    uint16 dseg = s->f15DataSeg;
+    uint8 * FAR *wtPtrsFar = (uint8 * FAR *)MK_FP(dseg, (uint16)g_fontWidthTables);
+    uint8 FAR *wt;
     if (fontIdx >= 8) return 8;
-    widths = g_fontWidthTables[fontIdx];
-    if (!widths) return 8; /* fixed-width fallback */
-    /* Chars >= 0x80 are inline color escapes — return 0 width
-     * (matches original overlay behavior) */
+    /* Chars >= 0x80 are inline color escapes - no glyph, no width */
     if (ch >= 0x80) return 0;
-    if (ch < 0x20) return widths[0]; /* space width for control chars */
-    return widths[ch - 0x20];
+    wt = wtPtrsFar[fontIdx]
+        ? (uint8 FAR *)MK_FP(dseg, (uint16)wtPtrsFar[fontIdx]) : (uint8 FAR *)0;
+    if (!wt || ch < 0x20) return 8;
+    return wt[ch - 0x20];
 }
 int FAR CDECL gfx_getAuxBufSize(void) { return 0x1950; }
-int FAR CDECL gfx_fontSetup(void) { return 0; }
-/* gfx_fillRow: ASM calling convention is DI=rowOffset, BP=srcBuf, BX=rowNum
- * In NO_ASM build, showPicFile is reimplemented in C and writes directly to page.
- * These stubs remain for any other callers. */
-int FAR CDECL gfx_fillRow(void) { return 0; }
-int FAR CDECL gfx_fillRow2(void) { return 0; }
-int FAR CDECL gfx_copyRow(void) { return 0; }
+int FAR CDECL gfx_fontSetup(uint16 ch, uint16 fontIdx)
+{
+    GfxState FAR *s = gfx_getState();
+    /* Store font settings in state */
+    (void)ch;
+    (void)fontIdx;
+    return 0;
+}
+/* gfx_fillRow (0x33) and gfx_copyRow (0x35) are register-called: their slot
+ * symbols are asm shims in regshim.asm -> gfx_fillRow_impl / gfx_copyRow_impl
+ * above. Slot 0x34 (fillRow2) is IDENTICAL to slot 0x33 in MGRAPHIC (both
+ * `rep movsw` the decoded row to ES:DI), so slot 0x34 points at the same
+ * gfx_fillRow shim — decodePic (pic_decodepic.inc) uses it to fill the
+ * caller's sprite buffer. This unused stub is kept only for legacy linkage. */
+int FAR CDECL gfx_fillRow2(uint16 x, uint16 y)
+{
+    (void)x;
+    (void)y;
+    return 0;
+}
 int FAR CDECL gfx_nop36(void) { return 0; }
 int FAR CDECL gfx_nop37(void) { return 0; }
 int FAR CDECL gfx_setFadeSteps(int steps) { (void)steps; return 0; }
-int FAR CDECL gfx_calcRowAddr(int y, int x) { return (int)(g_rowOffsets[y] + (uint16)x); }
-int FAR CDECL gfx_setOvlVal1(int val) { return 0; }
-int FAR CDECL gfx_setOvlVal2(int val) { return 0; }
-int FAR CDECL gfx_getBlitOffset(void) { return (int)g_blitOffset; }
-int FAR CDECL gfx_getModeFlag(void) { return (int)g_modeFlag; }
-int FAR CDECL gfx_getModeFlag2(void) { return (int)g_modeFlag; }
-int FAR CDECL gfx_getVal(void) { return 0; }
-int FAR CDECL gfx_getVal2(void) { return 0; }
-int FAR CDECL gfx_setDacAnimCount(uint16 count) { g_dacCounter = (uint8)count; return 0; }
+int FAR CDECL gfx_calcRowAddr(int y, int x)
+{
+    GfxState FAR *s = gfx_getState();
+    if (!s->rowOffsetsReady) return (int)(y * 320 + x);
+    return (int)(s->rowOffsets[y] + x);
+}
+int FAR CDECL gfx_setOvlVal1(int val) { (void)val; return 0; }
+int FAR CDECL gfx_setOvlVal2(int val) { (void)val; return 0; }
+int FAR CDECL gfx_getBlitOffset(void)
+{
+    GfxState FAR *s = gfx_getState();
+    return (int)s->blitOffset;
+}
+int FAR CDECL gfx_getModeFlag(void)
+{
+    GfxState FAR *s = gfx_getState();
+    return (int)s->modeFlag;
+}
+int FAR CDECL gfx_getModeFlag2(void)
+{
+    GfxState FAR *s = gfx_getState();
+    return (int)s->modeFlag;
+}
+int FAR CDECL gfx_getVal(uint16 val) { return (int)val; }
+int FAR CDECL gfx_getVal2(uint16 val) { return (int)val; }
+int FAR CDECL gfx_setDacAnimCount(uint16 count)
+{
+    GfxState FAR *s = gfx_getState();
+    s->dacCounter = (uint8)count;
+    return 0;
+}
 int FAR CDECL gfx_commitPage(void)
 {
-    /* Original slot 0x50 is RETF (no-op) — end.exe draws directly to VGA.
-     * Only copy if we're somehow drawing to a back buffer. */
-    if (g_curPageSeg != 0xA000 && g_curPageSeg != 0) {
-        movedata(g_curPageSeg, 0, 0xA000, 0, 64000u);
+    GfxState FAR *s = gfx_getState();
+    /* Original slot 0x50 is RETF (no-op) - end.exe draws directly to VGA.
+     * Only copy if we're drawing to a back buffer. */
+    if (s->pageSegs[0] != 0xA000 && s->pageSegs[0] != 0) {
+        movedata(s->pageSegs[0], 0, 0xA000, 0, 64000u);
     }
     return 0;
 }
@@ -533,6 +731,285 @@ int FAR CDECL gfx_blitSpriteOpaque2(void) { return 0; }
 /* ---- Slot 0x30: gfx_blitToCurrent ---- */
 int FAR CDECL gfx_blitToCurrent(int16 pagePtr)
 {
-    movedata((uint16)pagePtr, 0, g_curPageSeg, 0, 64000u);
+    GfxState FAR *s = gfx_getState();
+    movedata((uint16)pagePtr, 0, s->curPageSeg, 0, 64000u);
     return 0;
+}
+
+/* ---- Stubs for declared-but-unimplemented slots ---- */
+int FAR CDECL gfx_blitVariant(void)        { return 0; }
+int FAR CDECL gfx_copyBlock(void)           { return 0; }
+int FAR CDECL gfx_drawStringUnclipped(void) { return 0; }
+int FAR CDECL gfx_clipRight(void)           { return 0; }
+int FAR CDECL gfx_clipTop(void)             { return 0; }
+int FAR CDECL gfx_clipLeft(void)            { return 0; }
+int FAR CDECL gfx_clipBottom(void)          { return 0; }
+int FAR CDECL gfx_complexRender(void)       { return 0; }
+int FAR CDECL gfx_blitCore(void)            { return 0; }
+int FAR CDECL gfx_spriteVariant1(void)      { return 0; }
+int FAR CDECL gfx_spriteVariant2(void)      { return 0; }
+int FAR CDECL gfx_nop15(void)              { return 0; }
+int FAR CDECL gfx_nop16(void)              { return 0; }
+int FAR CDECL gfx_setBlitOffset2(void)      { GfxState FAR *s=gfx_getState(); s->blitOffset=0; return 0; }
+int FAR CDECL gfx_setBlitOffset3(void)      { GfxState FAR *s=gfx_getState(); s->blitOffset=0; return 0; }
+int FAR CDECL gfx_getAuxSize(void)          { return 0x1950; }
+int FAR CDECL gfx_setClipVal1(void)         { return 0; }
+int FAR CDECL gfx_setClipVal2(void)         { return 0; }
+int FAR CDECL gfx_nop24(void)              { return 0; }
+int FAR CDECL gfx_storePageSeg(void)        { return 0; }
+int FAR CDECL gfx_setPageSeg(void)          { return 0; }
+int FAR CDECL gfx_unknown2b(void)           { return 0; }
+int FAR CDECL gfx_dacAnimate(void)          { GfxState FAR *s=gfx_getState(); return 0; }
+int FAR CDECL gfx_unknown2e(void)           { return 0; }
+int FAR CDECL gfx_setPageBuf(void)          { return 0; }
+int FAR CDECL gfx_unknown43(void)           { return 0; }
+
+/* ---- Slot function pointer table (84 entries, slots 0x00–0x53) ---- */
+/* MSC 5.1 forbids cast expressions in static initializers (C2097), so this
+ * array starts zero-initialised and is filled at runtime by gfx_buildVirtualOverlay. */
+GfxSlotFn gfxSlotTable[0x54];
+
+static void fillSlotTable(void)
+{
+    gfxSlotTable[0x00] = (GfxSlotFn)gfx_allocPage;
+    gfxSlotTable[0x01] = (GfxSlotFn)gfx_fillDirty;
+    gfxSlotTable[0x02] = (GfxSlotFn)gfx_blitTransparent;
+    gfxSlotTable[0x03] = (GfxSlotFn)gfx_blitVariant;
+    gfxSlotTable[0x04] = (GfxSlotFn)gfx_copyBlock;
+    gfxSlotTable[0x05] = (GfxSlotFn)gfx_drawString;
+    gfxSlotTable[0x06] = (GfxSlotFn)gfx_drawStringUnclipped;
+    gfxSlotTable[0x07] = (GfxSlotFn)gfx_clipRight;
+    gfxSlotTable[0x08] = (GfxSlotFn)gfx_clipTop;
+    gfxSlotTable[0x09] = (GfxSlotFn)gfx_clipLeft;
+    gfxSlotTable[0x0a] = (GfxSlotFn)gfx_clipBottom;
+    gfxSlotTable[0x0b] = (GfxSlotFn)gfx_complexRender;
+    gfxSlotTable[0x0c] = (GfxSlotFn)gfx_initOverlay;
+    gfxSlotTable[0x0d] = (GfxSlotFn)gfx_setPage1;
+    gfxSlotTable[0x0e] = (GfxSlotFn)gfx_setPageN;
+    gfxSlotTable[0x0f] = (GfxSlotFn)gfx_getCurPageSeg;
+    gfxSlotTable[0x10] = (GfxSlotFn)gfx_getCurPageSeg2;
+    gfxSlotTable[0x11] = (GfxSlotFn)gfx_blitSprite;
+    gfxSlotTable[0x12] = (GfxSlotFn)gfx_blitCore;
+    gfxSlotTable[0x13] = (GfxSlotFn)gfx_spriteVariant1;
+    gfxSlotTable[0x14] = (GfxSlotFn)gfx_spriteVariant2;
+    gfxSlotTable[0x15] = (GfxSlotFn)gfx_nop15;
+    gfxSlotTable[0x16] = (GfxSlotFn)gfx_nop16;
+    gfxSlotTable[0x17] = (GfxSlotFn)gfx_getBufSize;
+    gfxSlotTable[0x18] = (GfxSlotFn)gfx_setBlitOffset2;
+    gfxSlotTable[0x19] = (GfxSlotFn)gfx_setBlitOffset3;
+    gfxSlotTable[0x1a] = (GfxSlotFn)gfx_setBlitOffset;
+    gfxSlotTable[0x1b] = (GfxSlotFn)gfx_getAuxSize;
+    gfxSlotTable[0x1c] = (GfxSlotFn)gfx_getBlitOffset;
+    gfxSlotTable[0x1d] = (GfxSlotFn)gfx_setClipVal1;
+    gfxSlotTable[0x1e] = (GfxSlotFn)gfx_setClipVal2;
+    gfxSlotTable[0x1f] = (GfxSlotFn)gfx_drawLine;
+    gfxSlotTable[0x20] = (GfxSlotFn)gfx_setPageDirect;
+    gfxSlotTable[0x21] = (GfxSlotFn)gfx_setColor;
+    gfxSlotTable[0x22] = (GfxSlotFn)gfx_resetBlitOffset;
+    gfxSlotTable[0x23] = (GfxSlotFn)gfx_resetBlitOffset2;
+    gfxSlotTable[0x24] = (GfxSlotFn)gfx_nop24;
+    gfxSlotTable[0x25] = (GfxSlotFn)gfx_dirtyRect2; /* 0x25 == 0x28 in MGRAPHIC */
+    gfxSlotTable[0x26] = (GfxSlotFn)gfx_storePageSeg;
+    gfxSlotTable[0x27] = (GfxSlotFn)gfx_setPageSeg;
+    gfxSlotTable[0x28] = (GfxSlotFn)gfx_dirtyRect2;
+    gfxSlotTable[0x29] = (GfxSlotFn)gfx_switchColor;
+    gfxSlotTable[0x2a] = (GfxSlotFn)gfx_copyRect;
+    gfxSlotTable[0x2b] = (GfxSlotFn)gfx_unknown2b;
+    gfxSlotTable[0x2c] = (GfxSlotFn)gfx_dacAnimate;
+    gfxSlotTable[0x2d] = (GfxSlotFn)gfx_getDisplayPage;
+    gfxSlotTable[0x2e] = (GfxSlotFn)gfx_unknown2e;
+    gfxSlotTable[0x2f] = (GfxSlotFn)gfx_setFont;
+    gfxSlotTable[0x30] = (GfxSlotFn)gfx_blitToCurrent;
+    gfxSlotTable[0x31] = (GfxSlotFn)gfx_getAuxBufSize;
+    gfxSlotTable[0x32] = (GfxSlotFn)gfx_fontSetup;
+    gfxSlotTable[0x33] = (GfxSlotFn)gfx_fillRow;
+    gfxSlotTable[0x34] = (GfxSlotFn)gfx_fillRow;
+    gfxSlotTable[0x35] = (GfxSlotFn)gfx_copyRow;
+    gfxSlotTable[0x36] = (GfxSlotFn)gfx_nop36;
+    gfxSlotTable[0x37] = (GfxSlotFn)gfx_nop37;
+    gfxSlotTable[0x38] = (GfxSlotFn)gfx_getPageSeg;
+    gfxSlotTable[0x39] = (GfxSlotFn)gfx_setPageBuf;
+    gfxSlotTable[0x3a] = (GfxSlotFn)gfx_getRowOffset;
+    gfxSlotTable[0x3b] = (GfxSlotFn)gfx_clearPage;
+    gfxSlotTable[0x3c] = (GfxSlotFn)gfx_setMode13;
+    gfxSlotTable[0x3d] = (GfxSlotFn)gfx_setFadeSteps;
+    gfxSlotTable[0x3e] = (GfxSlotFn)gfx_calcRowAddr;
+    gfxSlotTable[0x3f] = (GfxSlotFn)gfx_getModecode;
+    gfxSlotTable[0x40] = (GfxSlotFn)gfx_setOvlVal1;
+    gfxSlotTable[0x41] = (GfxSlotFn)gfx_setOvlVal2;
+    gfxSlotTable[0x42] = (GfxSlotFn)gfx_getModeFlag2;
+    gfxSlotTable[0x43] = (GfxSlotFn)gfx_unknown43;
+    gfxSlotTable[0x44] = (GfxSlotFn)gfx_setDac;
+    gfxSlotTable[0x45] = (GfxSlotFn)gfx_waitRetrace;
+    gfxSlotTable[0x46] = (GfxSlotFn)gfx_flipPage;
+    gfxSlotTable[0x47] = (GfxSlotFn)gfx_blitSpriteClipped;
+    gfxSlotTable[0x48] = (GfxSlotFn)gfx_blitSpriteClipped2;
+    gfxSlotTable[0x49] = (GfxSlotFn)gfx_blitSpriteOpaque;
+    gfxSlotTable[0x4a] = (GfxSlotFn)gfx_blitSpriteOpaque2;
+    gfxSlotTable[0x4b] = (GfxSlotFn)gfx_storeBufPtr;
+    gfxSlotTable[0x4c] = (GfxSlotFn)gfx_getModeFlag;
+    gfxSlotTable[0x4d] = (GfxSlotFn)gfx_getVal2;
+    gfxSlotTable[0x4e] = (GfxSlotFn)gfx_getVal;
+    gfxSlotTable[0x4f] = (GfxSlotFn)gfx_setDacAnimCount;
+    gfxSlotTable[0x50] = (GfxSlotFn)gfx_commitPage;
+    gfxSlotTable[0x51] = (GfxSlotFn)gfx_nop51;
+    gfxSlotTable[0x52] = (GfxSlotFn)gfx_setMonoFlag;
+    gfxSlotTable[0x53] = (GfxSlotFn)gfx_getCurPage;
+}
+
+/* ---- Build the virtual overlay block ---- */
+/* OvlHeader-compatible block so setupOverlaySlots (lowlvl.asm) can patch
+ * start/end slot stubs to far-jump into f15.exe's gfx functions. */
+void gfx_buildVirtualOverlay(uint16 ovlSeg)
+{
+    uint16 codeSeg;
+    int i;
+    uint16 FAR *base;
+    GfxState FAR *s;
+
+    /* Populate slot table */
+    fillSlotTable();
+
+    /* Get f15.exe's code segment via a far pointer to a FAR-declared gfx function.
+     * In small model, FAR functions still reside in the one code segment (CS),
+     * so FP_SEG of any FAR function pointer gives CS. */
+    {
+        typedef int (FAR *FarFn)(void);
+        FarFn fp = (FarFn)gfx_allocPage;
+        codeSeg = FP_SEG(fp);
+    }
+
+    /* Zero the entire 80-paragraph (1280-byte) block */
+    base = (uint16 FAR *)MK_FP(ovlSeg, 0);
+    for (i = 0; i < 640; i++)
+        base[i] = 0;
+
+    /* OvlHeader fields read by setupOverlaySlots (lowlvl.asm) */
+    *(uint16 FAR *)MK_FP(ovlSeg, 0x18) = codeSeg; /* OVL_HDR_CODESEG  */
+    *(uint16 FAR *)MK_FP(ovlSeg, 0x1C) = 0;        /* OVL_HDR_FIRSTIDX */
+    *(uint16 FAR *)MK_FP(ovlSeg, 0x22) = 0x54;     /* OVL_HDR_SLOTCOUNT */
+
+    /* Slot offset table at 0x24 (immediately after slotCount@0x22): one uint16
+     * per slot. This is where the ASM setupOverlaySlots (overlay_slots.inc reads
+     * `mov si,24h`) expects it — NOT 0x244. */
+    for (i = 0; i < 0x54; i++)
+        *(uint16 FAR *)MK_FP(ovlSeg, 0x24 + i * 2) = (uint16)gfxSlotTable[i];
+
+    /* Initialize GfxState defaults */
+    s = (GfxState FAR *)MK_FP(ovlSeg, GFX_STATE_OFFSET);
+    s->modeFlag = 1;
+    s->rowOffsetsReady = 0;
+    for (i = 0; i < 16; i++) {
+        s->pageSegs[i] = 0;
+    }
+    /* Record f15.exe's DGROUP segment so gfx const tables remain reachable
+     * when a child far-calls in with its own DS (Finding A). This runs in
+     * f15.exe, so the far address of any DGROUP object carries f15's DS.
+     * FP_SEG needs an lvalue, so stage the far pointer in a local first. */
+    {
+        void FAR *anchorFp = (void FAR *)&dgroupAnchor;
+        s->f15DataSeg = FP_SEG(anchorFp);
+    }
+}
+
+/* ===================================================================
+ * Stub MISC and SOUND overlays — provided by f15.exe itself so the
+ * pure-DOS build does not depend on the original MISC.EXE / NSOUND.EXE.
+ *
+ *   - Sound is intentionally absent under DOS (roadmap: real audio only
+ *     on non-DOS targets), so every audio slot is a no-op.
+ *   - Misc is a placeholder: keyboard/joystick report "nothing pending"
+ *     so the splash auto-advances. Its real behaviour must be replicated
+ *     for a functional game.
+ *
+ * These reuse the same OvlHeader-compatible layout as the gfx overlay
+ * (codeSeg@0x18, firstIdx@0x1C, slotCount@0x22, offsets@0x24), so the
+ * child's ASM setupOverlaySlots patches them just like the real overlays.
+ * =================================================================== */
+
+/* Generic no-op far slot (return value lands in AX). */
+int FAR CDECL ovl_nop(void)            { return 0; }
+
+/* Misc/input slots (0x5a-0x5f), reimplemented faithfully from MISC.EXE so the
+ * pure-DOS build has working keyboard input without loading MISC.EXE.
+ *
+ * Original MISC.EXE disassembly:
+ *   0x5a keybuf: mov ah,1; int 16h; jz empty; sub ax,ax; retf  (0 = key avail)
+ *                empty: sub ax,ax; not ax; retf                (0xFFFF = empty)
+ *   0x5b getkey: sub ah,ah; int 16h; retf  (raw BIOS AX: AH=scan, AL=ascii;
+ *                callers in processStoreInput mask &0xff when AL!=0)
+ *   0x5e clearKeyFlags: zero the low nibble of BDA 0040:0417 (shift state) */
+
+/* Slot 0x5a: 0 if a key is waiting, 0xFFFF if the buffer is empty. INT 16h
+ * AH=01h sets ZF when empty, but int86() does not expose ZF — so test the
+ * BIOS keyboard buffer head/tail (0040:001A / 0040:001C), which is exactly
+ * what AH=01h inspects (equal => empty). */
+int FAR CDECL miscStub_keybuf(void)
+{
+    uint16 FAR *head = (uint16 FAR *)MK_FP(0x40, 0x1a);
+    uint16 FAR *tail = (uint16 FAR *)MK_FP(0x40, 0x1c);
+    return (*head == *tail) ? (int)0xFFFF : 0;
+}
+
+/* Slot 0x5b: return the raw BIOS keystroke (AH=scancode, AL=ascii). Blocks
+ * until a key is available, matching the original. */
+int FAR CDECL miscStub_getkey(void)
+{
+    union REGS r;
+    r.h.ah = 0;
+    int86(0x16, &r, &r);
+    return (int)r.x.ax;
+}
+
+int FAR CDECL miscStub_readJoy(void)       { return 0; }
+
+/* Slot 0x5e: clear the active-modifier low nibble of the BDA shift-flags byte. */
+int FAR CDECL miscStub_clearKeyFlags(void)
+{
+    uint8 FAR *flags = (uint8 FAR *)MK_FP(0x40, 0x17);
+    *flags &= 0xf0;
+    return 0;
+}
+
+/* Write an OvlHeader-compatible stub overlay covering `count` slots starting
+ * at `firstIdx`, pointing each at the corresponding fn (an f15.exe offset). */
+static void buildStubOverlay(uint16 ovlSeg, uint16 firstIdx, uint16 count,
+                             const GfxSlotFn *fns)
+{
+    uint16 codeSeg;
+    uint16 i;
+    uint16 FAR *base;
+    { typedef int (FAR *FarFn)(void);
+      FarFn fp = (FarFn)ovl_nop;
+      codeSeg = FP_SEG(fp); }
+    /* zero the header region (0x00..0x23) plus the offset table */
+    base = (uint16 FAR *)MK_FP(ovlSeg, 0);
+    for (i = 0; i < (uint16)(0x12 + count); i++)
+        base[i] = 0;
+    *(uint16 FAR *)MK_FP(ovlSeg, 0x18) = codeSeg;
+    *(uint16 FAR *)MK_FP(ovlSeg, 0x1C) = firstIdx;
+    *(uint16 FAR *)MK_FP(ovlSeg, 0x22) = count;
+    for (i = 0; i < count; i++)
+        *(uint16 FAR *)MK_FP(ovlSeg, 0x24 + i * 2) = (uint16)fns[i];
+}
+
+void gfx_buildMiscOverlay(uint16 ovlSeg)
+{
+    GfxSlotFn fns[6];
+    fns[0] = (GfxSlotFn)miscStub_keybuf;        /* 0x5a */
+    fns[1] = (GfxSlotFn)miscStub_getkey;        /* 0x5b */
+    fns[2] = (GfxSlotFn)ovl_nop;                /* 0x5c */
+    fns[3] = (GfxSlotFn)miscStub_readJoy;       /* 0x5d */
+    fns[4] = (GfxSlotFn)miscStub_clearKeyFlags; /* 0x5e */
+    fns[5] = (GfxSlotFn)ovl_nop;                /* 0x5f */
+    buildStubOverlay(ovlSeg, 0x5a, 6, fns);
+}
+
+void gfx_buildSoundOverlay(uint16 ovlSeg)
+{
+    GfxSlotFn fns[10];   /* slots 0x64-0x6d, all no-op (no sound) */
+    int i;
+    for (i = 0; i < 10; i++)
+        fns[i] = (GfxSlotFn)ovl_nop;
+    buildStubOverlay(ovlSeg, 0x64, 10, fns);
 }

--- a/src/gfx_impl.h
+++ b/src/gfx_impl.h
@@ -12,6 +12,47 @@
 #include "inttype.h"
 #include "pointers.h"
 
+/* Byte offset of GfxState within the virtual overlay block */
+#define GFX_STATE_OFFSET 0x2EC
+
+/* Shared gfx state stored in the virtual overlay block.
+ * gfx_impl.c functions will migrate to accessing this via far pointer in Phase 2.
+ */
+typedef struct {
+    uint16 rowOffsets[200]; /* replaces g_rowOffsets[] */
+    uint16 curPageSeg;      /* replaces g_curPageSeg  */
+    int16  blitOffset;      /* replaces g_blitOffset  */
+    uint8  modeFlag;        /* replaces g_modeFlag = 1 */
+    uint8  fillColor;       /* replaces g_fillColor   */
+    uint8  dacCounter;      /* replaces g_dacCounter  */
+    uint8  rowOffsetsReady; /* replaces g_rowOffsetsReady */
+    uint16 pageSegs[16];    /* replaces g_pageSegs[]  */
+    uint16 f15DataSeg;      /* FP_SEG of f15.exe's DGROUP — see Finding A.
+                             * Lets gfx functions reach their own const tables
+                             * (palettes, font tables) via far pointer when a
+                             * child far-calls in with DS = the child's DGROUP. */
+} GfxState;
+
+/* Near function pointer type for the gfx slot table */
+typedef int (*GfxSlotFn)(void);
+
+/* Far function pointer type for the slot trampoline table */
+typedef int (FAR *GfxFarFn)(void);
+
+/* 84-entry slot table used by f15.exe to call gfx functions directly and to
+ * fill the virtual overlay's slot_offsets[] array at startup */
+extern GfxSlotFn gfxSlotTable[0x54];
+
+/* Build the virtual overlay block at ovlSeg: write OvlHeader-compatible fields,
+ * fill slot_offsets[] with FP_OFF of each gfx function, init GfxState. */
+void gfx_buildVirtualOverlay(uint16 ovlSeg);
+
+/* Build stub MISC (slots 0x5a-0x5f) and SOUND (slots 0x64-0x6d) overlays from
+ * f15.exe — removes the dependency on MISC.EXE / NSOUND.EXE. Sound is a no-op
+ * (no DOS audio); misc is a placeholder (input reports nothing pending). */
+void gfx_buildMiscOverlay(uint16 ovlSeg);
+void gfx_buildSoundOverlay(uint16 ovlSeg);
+
 /*
  * Reference structures documenting how the overlay accesses caller data.
  * These CANNOT be used in the asm data segments (which must maintain exact

--- a/src/ovlpatch.c
+++ b/src/ovlpatch.c
@@ -1,0 +1,63 @@
+/*
+ * ovlpatch.c — C implementation of setupOverlaySlots() for virtual overlay.
+ *
+ * This function reads the virtual overlay header from DOS memory and populates
+ * the far-call trampoline table (gfxFarTableExported[]) with far pointers to
+ * f15.exe's code segment. Works identically for both real Mgraphic.exe and
+ * the virtual overlay since both use the same OvlHeader field offsets.
+ */
+
+#include "inttype.h"
+#include "pointers.h"
+#include "gfx_impl.h"
+#include "ovl.h"
+
+/* External declaration of the far-call table in slot_trampoline.c */
+extern GfxFarFn gfxFarTableExported[84];
+
+/* Byte offsets for reading overlay header (same as ASM build) */
+#define OVL_HDR_CODESEG 0x18     /* code segment */
+#define OVL_HDR_FIRSTIDX 0x1C    /* first slot index */
+#define OVL_HDR_SLOTCOUNT 0x22   /* number of slots */
+#define OVL_HDR_FIRSTPTR 0x24    /* slot_offsets[] array (right after slotCount@0x22) */
+
+/**
+ * @brief Populate the far-call trampoline table with pointers from the overlay.
+ *
+ * Reads the virtual overlay header and fills gfxFarTableExported[] with far
+ * pointers to functions in f15.exe's code segment. The offset array at
+ * OVL_HDR_FIRSTPTR contains FP_OFF() values for each slot function.
+ */
+void setupOverlaySlots(int param) /* ovlSeg passed as int */
+{
+    uint16 ovlSeg = param;
+    uint16 codeSeg;      /* Overlay code segment (f15.exe's CS) */
+    uint16 firstIdx;     /* First slot index (usually 0) */
+    uint16 slotCount;    /* Number of slots to patch */
+    int i;
+
+    /* Finding D: in NOASM the misc/sound drivers are never loaded, so
+     * miscOvlAddr/sndOvlAddr are 0. Reading a "header" from segment 0 would
+     * yield a garbage slotCount and corrupt gfxFarTableExported[]. Only the
+     * gfx overlay (a real segment) does any work here. */
+    if (ovlSeg == 0)
+        return;
+
+    /* Read overlay header fields from DOS memory via IACA/COMM */
+    codeSeg = *(uint16 FAR *)MK_FP(ovlSeg, OVL_HDR_CODESEG);
+    firstIdx = *(uint16 FAR *)MK_FP(ovlSeg, OVL_HDR_FIRSTIDX);
+    slotCount = *(uint16 FAR *)MK_FP(ovlSeg, OVL_HDR_SLOTCOUNT);
+
+    /* The trampoline table only covers the 84 gfx slots (0x00-0x53). The MISC
+     * (firstIdx 0x5a) and SOUND (firstIdx 0x64) overlays fall outside it — in a
+     * NO_ASM child those drivers are direct C, so skip patching for them rather
+     * than writing past gfxFarTableExported[]. */
+    if (firstIdx + slotCount > 84)
+        return;
+
+    /* Read slot_offsets[] array and populate trampoline table */
+    for (i = 0; i < slotCount; i++) {
+        uint16 off = *(uint16 FAR *)MK_FP(ovlSeg, OVL_HDR_FIRSTPTR + i * 2);
+        gfxFarTableExported[firstIdx + i] = (GfxFarFn)MK_FP(codeSeg, off);
+    }
+}

--- a/src/regshim.asm
+++ b/src/regshim.asm
@@ -1,0 +1,161 @@
+.8086
+DOSSEG
+.MODEL SMALL
+
+; regshim.asm — register-call ABI glue for f15.exe's virtual gfx overlay.
+;
+; A handful of original MGRAPHIC slots take their arguments in registers, not
+; on the stack (the ASM pic renderer in stcode.asm/pic_showpicfile.inc calls
+; them as `mov di,..; call far ptr _gfx_xxx`). MSC 5.1 has no inline asm and no
+; calling convention that receives args in DI/SI/BP/BX, so these tiny FAR shims
+; bridge the gap: capture the register args, push them as cdecl stack args, and
+; call the C body (gfx_*_impl in gfx_impl.c). DS is the caller's DGROUP on entry
+; and stays unchanged, so the C bodies read caller buffers via near pointers.
+;
+; The gfx slot table (gfxSlotTable / slot_offsets[]) points at these shims, so
+; setupOverlaySlots patches the child's JMP FAR slots to land here.
+
+PUBLIC _gfx_getRowOffset
+PUBLIC _gfx_getPageSeg
+PUBLIC _gfx_fillRow
+PUBLIC _gfx_copyRow
+PUBLIC _gfx_clearPage
+PUBLIC _gfx_setPage1
+PUBLIC _gfx_getCurPageSeg
+PUBLIC _gfx_getCurPageSeg2
+PUBLIC _gfx_setPageDirect
+PUBLIC _gfx_dirtyRect2
+
+EXTRN _gfx_getRowOffset_impl:NEAR
+EXTRN _gfx_getPageSeg_impl:NEAR
+EXTRN _gfx_fillRow_impl:NEAR
+EXTRN _gfx_copyRow_impl:NEAR
+EXTRN _gfx_clearPage_impl:NEAR
+EXTRN _gfx_setPage1_impl:NEAR
+EXTRN _gfx_setCurPageSeg_impl:NEAR
+EXTRN _gfx_getCurPageSeg2_impl:NEAR
+EXTRN _gfx_setFillColor_impl:NEAR
+EXTRN _gfx_dirtyRectFill_impl:NEAR
+
+.CODE
+
+; Slot 0x3a — DI = y; returns row byte offset in AX.
+; MUST also leave DI = rowOffset on return: decodePicRow (pic_lzw.inc) does
+; `shr di,1; jnz` on entry to decide whether to (re)initialise the LZW
+; dictionary — it expects DI = rowOffset (0 on the first row, >=320 after), not
+; the row number. Leaving DI = y would re-init the dict on row 1 and corrupt
+; the whole decode. MGRAPHIC's getRowOffset leaves DI = rowOffset; mirror that.
+_gfx_getRowOffset proc far
+    push di                         ; arg: y
+    call _gfx_getRowOffset_impl
+    add sp, 2
+    mov di, ax                      ; leave DI = rowOffset for decodePicRow
+    retf
+_gfx_getRowOffset endp
+
+; Slot 0x38 — SI = page; selects current page, returns its segment in AX.
+; MUST also leave ES = that segment: the original MGRAPHIC slot 0x38 does
+; `mov es,[cs:si*2+pageSegTable]`, and showPicFile (pic_showpicfile.inc) relies
+; on ES being the target page when the following _gfx_clearPage captures it.
+_gfx_getPageSeg proc far
+    push si                         ; arg: page
+    call _gfx_getPageSeg_impl
+    add sp, 2
+    mov es, ax                      ; leave ES = page segment (matches MGRAPHIC)
+    retf
+_gfx_getPageSeg endp
+
+; Slot 0x3b — ES = target segment (set by the caller: decodePic does `mov es,ax`,
+; showPicFile via _gfx_getPageSeg above). Capture ES as the current page and
+; clear it. fillRow/fillRow2 then write to that same captured segment, so the
+; decoded rows land in the caller's buffer even when ES is later clobbered.
+_gfx_clearPage proc far
+    push es                         ; arg: target segment
+    call _gfx_clearPage_impl
+    add sp, 2
+    retf
+_gfx_clearPage endp
+
+; Slot 0x33 — DI = rowOffset, BP = srcBuf, BX = rowNum.
+; cdecl args pushed right-to-left: rowNum, srcBuf, rowOffset.
+_gfx_fillRow proc far
+    push bx                         ; arg3: rowNum
+    push bp                         ; arg2: srcBuf
+    push di                         ; arg1: rowOffset
+    call _gfx_fillRow_impl
+    add sp, 6
+    retf
+_gfx_fillRow endp
+
+; Slot 0x35 — DI = rowOffset.
+_gfx_copyRow proc far
+    push di                         ; arg: rowOffset
+    call _gfx_copyRow_impl
+    add sp, 2
+    retf
+_gfx_copyRow endp
+
+; --- clearRect chain (gfx_clearrect.inc) — all register-called ---
+;
+; clearRect does `push DS; pop ES` then far-calls slots 0x10, 0x0d, 0x20 BEFORE
+; building its dirty-rect buffers with `rep stosw` (writing to ES:DI). The
+; original MGRAPHIC slots preserve ES across those calls; our C bodies call
+; gfx_getState(), which loads ES via MK_FP, so they WOULD clobber ES and the
+; stosw fills would land in the wrong segment (leaving the buffers unfilled, so
+; slot 0x28 clears nothing). These three shims therefore save/restore ES.
+
+; Slot 0x0d — AX = page index; curPageSeg = pageSegs[AX].
+; MUST preserve BX as well as ES: clearRect loads BX=pageNum, calls this, then
+; reads `mov AH,[BX+6]` (the fill colour) — so BX has to survive. MGRAPHIC's
+; slot 0x0d does push bx/pop bx; our C body clobbers BX, so save it here.
+_gfx_setPage1 proc far
+    push es                         ; preserve caller's ES (clearRect's stosw seg)
+    push bx                         ; preserve BX (clearRect reads [BX+6] after)
+    push ax                         ; arg: page index
+    call _gfx_setPage1_impl
+    add sp, 2
+    pop bx
+    pop es
+    retf
+_gfx_setPage1 endp
+
+; Slot 0x10 — returns curPageSeg in AX (clearRect saves it). Preserve ES.
+_gfx_getCurPageSeg2 proc far
+    push es
+    call _gfx_getCurPageSeg2_impl   ; returns AX = curPageSeg
+    pop es
+    retf
+_gfx_getCurPageSeg2 endp
+
+; Slot 0x0f — AX = segment; curPageSeg = AX (clearRect's restore; a SETTER).
+_gfx_getCurPageSeg proc far
+    push ax                         ; arg: segment
+    call _gfx_setCurPageSeg_impl
+    add sp, 2
+    retf
+_gfx_getCurPageSeg endp
+
+; Slot 0x20 — AH = fill colour; store it for the next clear/fill. Preserve ES.
+_gfx_setPageDirect proc far
+    push es                         ; preserve caller's ES (clearRect's stosw seg)
+    mov al, ah                      ; arg: colour (AH -> low byte)
+    xor ah, ah
+    push ax
+    call _gfx_setFillColor_impl
+    add sp, 2
+    pop es
+    retf
+_gfx_setPageDirect endp
+
+; Slot 0x25/0x28 — BX = &dirtyMinBuf (caller DS near), AX = yMin, CX = yMax.
+; cdecl args right-to-left: yMax, yMin, minBufOff.
+_gfx_dirtyRect2 proc far
+    push cx                         ; arg3: yMax
+    push ax                         ; arg2: yMin
+    push bx                         ; arg1: minBufOff
+    call _gfx_dirtyRectFill_impl
+    add sp, 6
+    retf
+_gfx_dirtyRect2 endp
+
+END

--- a/src/shared/gfxstub.c
+++ b/src/shared/gfxstub.c
@@ -23,12 +23,14 @@ void clearDirtyRects(void)
     /* Stub - dirty rect system not fully implemented yet */
 }
 
-/* gfx.inc: drawLineWrapper - clip and draw a line */
+/* gfx.inc: drawLineWrapper - draw a line.
+ * The original does Cohen-Sutherland clipping on the lineX1..lineY2 globals,
+ * then passes the (clipped) endpoints to slot 0x1f in registers. The C slot
+ * takes them by value, so marshal the globals here. (No clipping yet; the menu
+ * lines are already on-screen.) */
 void drawLineWrapper(void)
 {
-    /* Calls gfx_drawLine after Cohen-Sutherland clipping.
-       For stub: just call drawLine directly (no clipping) */
-    gfx_drawLine();
+    gfx_drawLine((uint16)lineX1, (uint16)lineY1, (uint16)lineX2, (uint16)lineY2);
 }
 
 /* gfx_clearrect.inc: clearRect - clear a rectangular region */
@@ -45,7 +47,8 @@ void clearRect(int16 *pageNum, int x1, int y1, int x2, int y2)
 
     color = (uint8)pageNum[3];
     gfx_setPageN(*pageNum);
-    pageSeg = (uint16)gfx_getCurPageSeg();
+    /* slot 0x10 (getCurPageSeg2) is the no-arg getter; slot 0x0f is a setter. */
+    pageSeg = (uint16)gfx_getCurPageSeg2();
     page = (uint8 far *)MK_FP(pageSeg, 0);
     if (x2 > 319) x2 = 319;
     if (y2 > 199) y2 = 199;

--- a/src/shared/miscstub.c
+++ b/src/shared/miscstub.c
@@ -45,11 +45,6 @@ void intDispatch(int intnum, uint8 *inreg, uint8 *outreg)
     outreg[1] = r.h.ah;
 }
 
-void setupOverlaySlots(int param)
-{
-    miscdbg("setupOverlaySlots called");
-}
-
 int doNothing2(const char *msg, int a, int b, int c)
 {
     return 0;

--- a/src/shared/ovlstub.c
+++ b/src/shared/ovlstub.c
@@ -23,8 +23,15 @@ extern int16  fileHandle;
 
 /* Misc input overlay slots - real DOS keyboard I/O */
 int far cdecl misc_jump_5a_keybuf(void) {
-    /* Check if key available. Return 0 if yes, 0xFFFF if not. */
-    if (kbhit())
+    /* Return 0 if a key is waiting, 0xFFFF if the buffer is empty.
+     * Read the BIOS keyboard buffer head/tail (0040:001A / 0040:001C)
+     * directly, matching the original MISC.EXE slot 0x5a. The C runtime's
+     * kbhit() reports a phantom "key ready" at startup here (probably via the
+     * INT 21h AH=0Bh stdin check), which made the splash/adv loop and
+     * processPilotInput auto-advance through every screen. */
+    uint16 far *head = (uint16 far *)MK_FP(0x40, 0x1A);
+    uint16 far *tail = (uint16 far *)MK_FP(0x40, 0x1C);
+    if (*head != *tail)
         return 0;
     return 0xFFFF;
 }

--- a/src/shared/picstub.c
+++ b/src/shared/picstub.c
@@ -8,10 +8,10 @@
 #include "inttype.h"
 #include "pointers.h"
 #include <dos.h>
+#include <conio.h>
 
 extern int FAR CDECL gfx_setPageN(uint16 pageNum);
-extern int FAR CDECL gfx_clearPage(void);
-extern int FAR CDECL gfx_getCurPageSeg(void);
+extern int FAR CDECL gfx_getCurPageSeg2(void);
 
 void picdbg(const char *msg)
 {
@@ -72,7 +72,7 @@ static uint16 dictParent[2048];
 static uint8 dictChar[2048];
 
 /* LZW output buffer (coroutine simulation) */
-static uint8 lzwOutBuf[2048];
+static uint8 lzwOutBuf[4096];   /* must cover the stackTop<4096 traversal guard */
 static uint16 lzwOutPos;
 static uint16 lzwOutLen;
 static int lzwFirstCode; /* flag: first code after init/reset */
@@ -259,7 +259,18 @@ static void decodeRow(uint8 *outBuf, uint16 count)
     }
 }
 
-static void picDecodeToSegment(int handle, uint16 pageSeg)
+/* rowCount/rowStride select the layout: mode-13h (200, 320) for full-screen
+ * 320x200 pics, or the EGA-title layout (0x2BC, 0x28) used by picBlit (mirrors
+ * _picBlit in stcode.asm). decodePicRow always produces a 320-byte row
+ * (picRowLength=320); the stride is what differs between the two paths.
+ *
+ * planar != 0 selects EGA mode-0x10 output: each decoded row is 320 8bpp pixels
+ * (colour 0-15); they are written to the 4 EGA bit-planes (1 bit/pixel/plane)
+ * via the Sequencer Map Mask (port 0x3C4 index 2). The original game does this
+ * conversion inside EGRAPHIC.EXE's fillRow; the NO_ASM build has no overlay
+ * driver, so we do it here. (Mode-13h pics use planar=0: a plain linear copy.) */
+static void picDecodeToSegment(int handle, uint16 pageSeg, uint16 rowCount,
+                               uint16 rowStride, int planar)
 {
     uint16 row;
     uint16 i;
@@ -298,7 +309,7 @@ static void picDecodeToSegment(int handle, uint16 pageSeg)
     rlePrevByte = 0;
     rleProcessFlag = 0;
 
-    for (row = 0; row < 200; row++) {
+    for (row = 0; row < rowCount; row++) {
         if (!picSignedFlag) {
             /* picByteUnsignedFlag=1 (bit7 clear): NIBBLE mode */
             decodeRow(tempBuf, 160);
@@ -311,10 +322,33 @@ static void picDecodeToSegment(int handle, uint16 pageSeg)
             decodeRow(picDecodedRowBuf, 320);
         }
 
-        dst = (uint8 far *)MK_FP(pageSeg, (uint16)(row * 320));
-        for (i = 0; i < 320; i++) {
-            dst[i] = picDecodedRowBuf[i];
+        dst = (uint8 far *)MK_FP(pageSeg, (uint16)(row * rowStride));
+        if (planar) {
+            /* 320 8bpp pixels -> 40 packed bytes per plane (8 px/byte, MSB =
+             * leftmost). Map Mask selects one plane per pass so the four writes
+             * to the same 40 addresses land in separate bit-planes. */
+            int p;
+            for (p = 0; p < 4; p++) {
+                int k;
+                outp(0x3C4, 2);
+                outp(0x3C5, 1 << p);
+                for (k = 0; k < 40; k++) {
+                    uint8 b = 0;
+                    int j;
+                    for (j = 0; j < 8; j++)
+                        b = (uint8)((b << 1) | ((picDecodedRowBuf[k * 8 + j] >> p) & 1));
+                    dst[k] = b;
+                }
+            }
+        } else {
+            for (i = 0; i < 320; i++) {
+                dst[i] = picDecodedRowBuf[i];
+            }
         }
+    }
+    if (planar) {
+        outp(0x3C4, 2);
+        outp(0x3C5, 0x0F);   /* restore Map Mask = all planes */
     }
 }
 
@@ -325,25 +359,43 @@ void showPicFile(int handle, int page)
     if (handle < 0) return;
 
     gfx_setPageN((uint16)page);
-    gfx_clearPage();
-    pageSeg = (uint16)gfx_getCurPageSeg();
-    picDecodeToSegment(handle, pageSeg);
+    /* No gfx_clearPage(): that slot (0x3b) is register-called (target seg in ES)
+     * via regshim, so a C trampoline call clears 64000 bytes at a wild ES. The
+     * decoder below writes every byte of all 200 rows, so the clear is redundant. */
+    pageSeg = (uint16)gfx_getCurPageSeg2();
+    picDecodeToSegment(handle, pageSeg, 200, 320, 0);
 }
 
 void decodePic(int handle, int segment)
 {
-    gfx_clearPage();
-    picDecodeToSegment(handle, (uint16)segment);
+    /* See showPicFile: the full-page decode makes gfx_clearPage() redundant
+     * (and unsafe to call from C). */
+    picDecodeToSegment(handle, (uint16)segment, 200, 320, 0);
 }
 
 void decodePicRaw(int handle, int segment)
 {
-    /* Same as decodePic: clears page and decodes PIC row-by-row */
-    gfx_clearPage();
-    picDecodeToSegment(handle, (uint16)segment);
+    /* Same as decodePic: decodes PIC row-by-row, fully overwriting the page. */
+    picDecodeToSegment(handle, (uint16)segment, 200, 320, 0);
 }
 
-void picBlit(int handle, int segment)
+/* picBlit mirrors _picBlit (stcode.asm): the 2nd arg is a PAGE INDEX (not a
+ * segment); showPic640 passes 0 -> pageSegs[0] = 0xA000. The decode uses the
+ * EGA-title layout: 0x2BC (700) rows at a 0x28 (40) byte stride, written to the
+ * resolved page segment. (decodePic, by contrast, takes a real segment and the
+ * mode-13h 200x320 layout.) */
+void picBlit(int handle, int pageIndex)
 {
-    decodePic(handle, segment);
+    uint16 seg;
+    uint16 i;
+    uint8 far *p;
+
+    if (handle < 0) return;
+
+    gfx_setPageN((uint16)pageIndex);
+    seg = (uint16)gfx_getCurPageSeg2();
+    /* mirror the _gfx_clearPage that _picBlit issues before decoding */
+    p = (uint8 far *)MK_FP(seg, 0);
+    for (i = 0; i < 32000u; i++) ((uint16 far *)p)[i] = 0;
+    picDecodeToSegment(handle, seg, 0x2BC, 0x28, 1);
 }

--- a/src/slot.h
+++ b/src/slot.h
@@ -38,7 +38,7 @@ int FAR CDECL gfx_getAuxSize();                        /* slot 0x1b: returns 0x1
 int FAR CDECL gfx_getBlitOffset();                     /* slot 0x1c: returns blitOffset */
 int FAR CDECL gfx_setClipVal1();                       /* slot 0x1d: writes ds:0xcc */
 int FAR CDECL gfx_setClipVal2();                       /* slot 0x1e: writes ds:0xce */
-int FAR CDECL gfx_drawLine();                          /* slot 0x1f: drawLine (Bresenham) */
+int FAR CDECL gfx_drawLine(uint16 x1, uint16 y1, uint16 x2, uint16 y2); /* slot 0x1f: drawLine (Bresenham) */
 int FAR CDECL gfx_setPageDirect();                     /* slot 0x20: set curPageSeg from AX */
 int FAR CDECL gfx_setColor(int color);                 /* slot 0x21: set fill/draw color */
 int FAR CDECL gfx_resetBlitOffset();                   /* slot 0x22: reset blitOffset=0 */

--- a/src/slottram.c
+++ b/src/slottram.c
@@ -1,0 +1,518 @@
+/*
+ * slot_trampoline.c — Far-call wrapper functions for the virtual overlay.
+ */
+
+#include "inttype.h"
+#include "pointers.h"
+#include "gfx_impl.h"
+#include "slot.h"
+
+/* GfxFarFn is defined in gfx_impl.h */
+
+/* Public far-call table populated by setupOverlaySlots() */
+GfxFarFn gfxFarTableExported[84] = {0};
+
+/* Slot 0x00: gfx_allocPage */
+int FAR CDECL gfx_allocPage(int pageNum)
+{
+    return ((int(FAR*)(int))gfxFarTableExported[0])(pageNum);
+}
+
+/* Slot 0x01: gfx_fillDirty */
+int FAR CDECL gfx_fillDirty(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[1])();
+}
+
+/* Slot 0x02: gfx_blitTransparent */
+int FAR CDECL gfx_blitTransparent(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[2])();
+}
+
+/* Slot 0x03: gfx_blitVariant */
+int FAR CDECL gfx_blitVariant(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[3])();
+}
+
+/* Slot 0x04: gfx_copyBlock */
+int FAR CDECL gfx_copyBlock(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[4])();
+}
+
+/* Slot 0x05: gfx_drawString */
+int FAR CDECL gfx_drawString(int16 *pageNum, const char *string)
+{
+    return ((int(FAR*)(int,int))gfxFarTableExported[5])(pageNum, string);
+}
+
+/* Slot 0x06: gfx_drawStringUnclipped */
+int FAR CDECL gfx_drawStringUnclipped(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[6])();
+}
+
+/* Slot 0x07: gfx_clipRight */
+int FAR CDECL gfx_clipRight(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[7])();
+}
+
+/* Slot 0x08: gfx_clipTop */
+int FAR CDECL gfx_clipTop(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[8])();
+}
+
+/* Slot 0x09: gfx_clipLeft */
+int FAR CDECL gfx_clipLeft(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[9])();
+}
+
+/* Slot 0x0a: gfx_clipBottom */
+int FAR CDECL gfx_clipBottom(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[10])();
+}
+
+/* Slot 0x0b: gfx_complexRender */
+int FAR CDECL gfx_complexRender(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[11])();
+}
+
+/* Slot 0x0c: gfx_initOverlay */
+int FAR CDECL gfx_initOverlay(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[12])();
+}
+
+/* Slot 0x0d: gfx_setPage1 */
+int FAR CDECL gfx_setPage1(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[13])();
+}
+
+/* Slot 0x0e: gfx_setPageN */
+int FAR CDECL gfx_setPageN(uint16 pageNum)
+{
+    return ((int(FAR*)(uint16))gfxFarTableExported[14])(pageNum);
+}
+
+/* Slot 0x0f: gfx_getCurPageSeg */
+int FAR CDECL gfx_getCurPageSeg(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[15])();
+}
+
+/* Slot 0x10: gfx_getCurPageSeg2 */
+int FAR CDECL gfx_getCurPageSeg2(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[16])();
+}
+
+/* Slot 0x11: gfx_blitSprite */
+int FAR CDECL gfx_blitSprite(struct SpriteParams *spritePtr)
+{
+    return ((int(FAR*)(int))gfxFarTableExported[17])(spritePtr);
+}
+
+/* Slot 0x12: gfx_blitCore */
+int FAR CDECL gfx_blitCore(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[18])();
+}
+
+/* Slot 0x13: gfx_spriteVariant1 */
+int FAR CDECL gfx_spriteVariant1(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[19])();
+}
+
+/* Slot 0x14: gfx_spriteVariant2 */
+int FAR CDECL gfx_spriteVariant2(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[20])();
+}
+
+/* Slot 0x15: gfx_nop15 */
+int FAR CDECL gfx_nop15(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[21])();
+}
+
+/* Slot 0x16: gfx_nop16 */
+int FAR CDECL gfx_nop16(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[22])();
+}
+
+/* Slot 0x17: gfx_getBufSize */
+int FAR CDECL gfx_getBufSize(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[23])();
+}
+
+/* Slot 0x18: gfx_setBlitOffset2 */
+int FAR CDECL gfx_setBlitOffset2(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[24])();
+}
+
+/* Slot 0x19: gfx_setBlitOffset3 */
+int FAR CDECL gfx_setBlitOffset3(int offset)
+{
+    return ((int(FAR*)(int))gfxFarTableExported[25])(offset);
+}
+
+/* Slot 0x1a: gfx_setBlitOffset */
+int FAR CDECL gfx_setBlitOffset(int offset)
+{
+    return ((int(FAR*)(int))gfxFarTableExported[26])(offset);
+}
+
+/* Slot 0x1b: gfx_getAuxSize */
+int FAR CDECL gfx_getAuxSize(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[27])();
+}
+
+/* Slot 0x1c: gfx_getBlitOffset */
+int FAR CDECL gfx_getBlitOffset(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[28])();
+}
+
+/* Slot 0x1d: gfx_setClipVal1 */
+int FAR CDECL gfx_setClipVal1(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[29])();
+}
+
+/* Slot 0x1e: gfx_setClipVal2 */
+int FAR CDECL gfx_setClipVal2(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[30])();
+}
+
+/* Slot 0x1f: gfx_drawLine — coords passed by value (the original takes them in
+ * registers; drawLineWrapper marshals the lineX1..lineY2 globals here). */
+int FAR CDECL gfx_drawLine(uint16 x1, uint16 y1, uint16 x2, uint16 y2)
+{
+    return ((int(FAR*)(uint16,uint16,uint16,uint16))gfxFarTableExported[31])(x1, y1, x2, y2);
+}
+
+/* Slot 0x20: gfx_setPageDirect */
+int FAR CDECL gfx_setPageDirect(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[32])();
+}
+
+/* Slot 0x21: gfx_setColor */
+int FAR CDECL gfx_setColor(int color)
+{
+    return ((int(FAR*)(uint8))gfxFarTableExported[33])(color);
+}
+
+/* Slot 0x22: gfx_resetBlitOffset */
+int FAR CDECL gfx_resetBlitOffset(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[34])();
+}
+
+/* Slot 0x23: gfx_resetBlitOffset2 */
+int FAR CDECL gfx_resetBlitOffset2(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[35])();
+}
+
+/* Slot 0x24: gfx_nop24 */
+int FAR CDECL gfx_nop24(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[36])();
+}
+
+/* Slot 0x25: gfx_dirtyRect */
+int FAR CDECL gfx_dirtyRect(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[37])();
+}
+
+/* Slot 0x26: gfx_storePageSeg */
+int FAR CDECL gfx_storePageSeg(uint16 seg, int pageIdx)
+{
+    return ((int(FAR*)(uint16,int))gfxFarTableExported[38])(seg, pageIdx);
+}
+
+/* Slot 0x27: gfx_setPageSeg */
+int FAR CDECL gfx_setPageSeg(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[39])();
+}
+
+/* Slot 0x28: gfx_dirtyRect2 */
+int FAR CDECL gfx_dirtyRect2(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[40])();
+}
+
+/* Slot 0x29: gfx_switchColor */
+int FAR CDECL gfx_switchColor(int16 *pageDesc, int x1, int y1, int x2, int y2, int oldColor, int newColor)
+{
+    return ((int(FAR*)(int16*,int,int,int,int,int,int))gfxFarTableExported[41])(pageDesc, x1, y1, x2, y2, oldColor, newColor);
+}
+
+/* Slot 0x2a: gfx_copyRect */
+int FAR CDECL gfx_copyRect(int srcPage, uint16 srcX, uint16 srcY, int dstPage, uint16 dstX, uint16 dstY, int width, int height)
+{
+    return ((int(FAR*)(int,uint16,uint16,int,uint16,uint16,int,int))gfxFarTableExported[42])(srcPage, srcX, srcY, dstPage, dstX, dstY, width, height);
+}
+
+/* Slot 0x2b: gfx_unknown2b */
+int FAR CDECL gfx_unknown2b(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[43])();
+}
+
+/* Slot 0x2c: gfx_dacAnimate */
+int FAR CDECL gfx_dacAnimate(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[44])();
+}
+
+/* Slot 0x2d: gfx_getDisplayPage */
+int FAR CDECL gfx_getDisplayPage(void)
+{
+    return ((int(FAR*)(uint16))gfxFarTableExported[45])(0);
+}
+
+/* Slot 0x2e: gfx_unknown2e */
+int FAR CDECL gfx_unknown2e(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[46])();
+}
+
+/* Slot 0x2f: gfx_setFont */
+int FAR CDECL gfx_setFont(uint16 ch, uint16 fontIdx)
+{
+    return ((int(FAR*)(uint16,uint16))gfxFarTableExported[47])(ch, fontIdx);
+}
+
+/* Slot 0x30: gfx_blitToCurrent */
+int FAR CDECL gfx_blitToCurrent(int16 pagePtr)
+{
+    return ((int(FAR*)(int))gfxFarTableExported[48])(pagePtr);
+}
+
+/* Slot 0x31: gfx_getAuxBufSize */
+int FAR CDECL gfx_getAuxBufSize(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[49])();
+}
+
+/* Slot 0x32: gfx_fontSetup */
+int FAR CDECL gfx_fontSetup(uint16 ch, uint16 fontIdx)
+{
+    return ((int(FAR*)(uint16,uint16))gfxFarTableExported[50])(ch, fontIdx);
+}
+
+/* Slot 0x33: gfx_fillRow */
+int FAR CDECL gfx_fillRow(int x, int y)
+{
+    return ((int(FAR*)(int,int))gfxFarTableExported[51])(x, y);
+}
+
+/* Slot 0x34: gfx_fillRow2 */
+int FAR CDECL gfx_fillRow2(int x, int y)
+{
+    return ((int(FAR*)(int,int))gfxFarTableExported[52])(x, y);
+}
+
+/* Slot 0x35: gfx_copyRow */
+int FAR CDECL gfx_copyRow(int x, int y)
+{
+    return ((int(FAR*)(int,int))gfxFarTableExported[53])(x, y);
+}
+
+/* Slot 0x36: gfx_nop36 */
+int FAR CDECL gfx_nop36(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[54])();
+}
+
+/* Slot 0x37: gfx_nop37 */
+int FAR CDECL gfx_nop37(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[55])();
+}
+
+/* Slot 0x38: gfx_getPageSeg */
+int FAR CDECL gfx_getPageSeg(uint16 page)
+{
+    return ((int(FAR*)(uint16))gfxFarTableExported[56])(page);
+}
+
+/* Slot 0x39: gfx_setPageBuf */
+int FAR CDECL gfx_setPageBuf(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[57])();
+}
+
+/* Slot 0x3a: gfx_getRowOffset */
+int FAR CDECL gfx_getRowOffset(int y)
+{
+    return ((int(FAR*)(uint16))gfxFarTableExported[58])(y);
+}
+
+/* Slot 0x3b: gfx_clearPage */
+int FAR CDECL gfx_clearPage(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[59])();
+}
+
+/* Slot 0x3c: gfx_setMode13 */
+int FAR CDECL gfx_setMode13(int16 monoFlag)
+{
+    return ((int(FAR*)(int))gfxFarTableExported[60])(monoFlag);
+}
+
+/* Slot 0x3d: gfx_setFadeSteps */
+int FAR CDECL gfx_setFadeSteps(int steps)
+{
+    return ((int(FAR*)(uint16))gfxFarTableExported[61])(steps);
+}
+
+/* Slot 0x3e: gfx_calcRowAddr */
+int FAR CDECL gfx_calcRowAddr(int y, int x)
+{
+    return ((int(FAR*)(int,int))gfxFarTableExported[62])(y, x);
+}
+
+/* Slot 0x3f: gfx_getModecode */
+int FAR CDECL gfx_getModecode(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[63])();
+}
+
+/* Slot 0x40: gfx_setOvlVal1 */
+int FAR CDECL gfx_setOvlVal1(int val)
+{
+    return ((int(FAR*)(uint16))gfxFarTableExported[64])(val);
+}
+
+/* Slot 0x41: gfx_setOvlVal2 */
+int FAR CDECL gfx_setOvlVal2(int val)
+{
+    return ((int(FAR*)(uint16))gfxFarTableExported[65])(val);
+}
+
+/* Slot 0x42: gfx_getModeFlag2 */
+int FAR CDECL gfx_getModeFlag2(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[66])();
+}
+
+/* Slot 0x43: gfx_unknown43 */
+int FAR CDECL gfx_unknown43(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[67])();
+}
+
+/* Slot 0x44: gfx_setDac */
+void FAR CDECL gfx_setDac(uint16 palIdx)
+{
+    ((void(FAR*)(uint16))gfxFarTableExported[68])(palIdx);
+}
+
+/* Slot 0x45: gfx_waitRetrace */
+int FAR CDECL gfx_waitRetrace(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[69])();
+}
+
+/* Slot 0x46: gfx_flipPage */
+int FAR CDECL gfx_flipPage(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[70])();
+}
+
+/* Slot 0x47: gfx_blitSpriteClipped */
+int FAR CDECL gfx_blitSpriteClipped(int16 *ptr)
+{
+    return ((int(FAR*)(int))gfxFarTableExported[71])(ptr);
+}
+
+/* Slot 0x48: gfx_blitSpriteClipped2 */
+int FAR CDECL gfx_blitSpriteClipped2(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[72])();
+}
+
+/* Slot 0x49: gfx_blitSpriteOpaque */
+int FAR CDECL gfx_blitSpriteOpaque(int16 *ptr)
+{
+    return ((int(FAR*)(int))gfxFarTableExported[73])(ptr);
+}
+
+/* Slot 0x4a: gfx_blitSpriteOpaque2 */
+int FAR CDECL gfx_blitSpriteOpaque2(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[74])();
+}
+
+/* Slot 0x4b: gfx_storeBufPtr */
+int FAR CDECL gfx_storeBufPtr(uint16 seg, int pageIdx)
+{
+    return ((int(FAR*)(uint16,int))gfxFarTableExported[75])(seg, pageIdx);
+}
+
+/* Slot 0x4c: gfx_getModeFlag */
+int FAR CDECL gfx_getModeFlag(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[76])();
+}
+
+/* Slot 0x4d: gfx_getVal2 */
+int FAR CDECL gfx_getVal2(int16 *p)
+{
+    return ((int(FAR*)(int))gfxFarTableExported[77])(p);
+}
+
+/* Slot 0x4e: gfx_getVal */
+int FAR CDECL gfx_getVal(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[78])();
+}
+
+/* Slot 0x4f: gfx_setDacAnimCount */
+int FAR CDECL gfx_setDacAnimCount(uint16 count)
+{
+    return ((int(FAR*)(uint16))gfxFarTableExported[79])(count);
+}
+
+/* Slot 0x50: gfx_commitPage */
+int FAR CDECL gfx_commitPage(void)
+{
+    return ((int(FAR*)(uint16))gfxFarTableExported[80])(0);
+}
+
+/* Slot 0x51: gfx_nop51 */
+int FAR CDECL gfx_nop51(void)
+{
+    return ((int(FAR*)(void))gfxFarTableExported[81])();
+}
+
+/* Slot 0x52: gfx_setMonoFlag */
+int FAR CDECL gfx_setMonoFlag(uint16 mono)
+{
+    return ((int(FAR*)(uint16))gfxFarTableExported[82])(mono);
+}
+
+/* Slot 0x53: gfx_getCurPage */
+int FAR CDECL gfx_getCurPage(int page)
+{
+    return ((int(FAR*)(uint16))gfxFarTableExported[83])(page);
+}

--- a/src/stmain.c
+++ b/src/stmain.c
@@ -101,7 +101,6 @@ int main(void)
         /* 0x17c */
         TRACE(("main: checking ega"));
 checkEga:
-#ifndef NO_ASM
         if (commData->gfxModeNum >= GFX_MODE_EGA && (*MAKEFAR(uint8, SEG_BDA, OFF_BDA_EGASWITCH) & EGA_SWITCH_MASK) == EGA_SWITCH_VALUE) {
             TRACE(("main: switching to ega for title"));
             /* 0x19c */
@@ -115,7 +114,6 @@ checkEga:
         }
         /* 0x1c5 */
         else
-#endif
         {
             TRACE(("main: doing 16color title"));
             gfx_setFadeSteps(1);
@@ -138,7 +136,6 @@ checkEga:
         audio_jump_67();
         if (isPcSpeaker == 0) restoreTimerIrqHandler();
         /* 0x23c */
-#ifndef NO_ASM
         if (commData->gfxModeNum >= GFX_MODE_EGA && (*MAKEFAR(uint8, SEG_BDA, OFF_BDA_EGASWITCH) & EGA_SWITCH_MASK) == EGA_SWITCH_VALUE) {
             TRACE(("main: restoring old overlay after title"));
             gfx_setDac(2);
@@ -152,7 +149,6 @@ checkEga:
         }
         /* 0x28c */
         else
-#endif
         {
             TRACE(("main: after 16 title"));
             gfx_setDac(0);


### PR DESCRIPTION
This commit implements the C-based NO_ASM build for F15 SE2 graphics subsystem, enabling runtime far pointer access to f15.exe's code segment via the virtual overlay. 

Refactors gfx_impl.* to use shared GfxState structure with proper FP_SEG/FP_OFF macros for accessing const tables regardless of caller's DS. Removes stub implementations from miscstub.c in favor of the new overlay-aware functions. 